### PR TITLE
`parseExpression` method and fixed error reporting to REPLs

### DIFF
--- a/apps/yukigo-docs/docs/components/CodePlayground.vue
+++ b/apps/yukigo-docs/docs/components/CodePlayground.vue
@@ -127,13 +127,11 @@ const inputRef = ref(null);
 const terminalBodyRef = ref(null);
 
 let parser = new YukigoHaskellParser();
-let replParser = new YukigoHaskellParser("");
 
 function switchLanguage(lang) {
   selectedLanguage.value = lang;
   const example = languageExamples[lang];
   parser = example.parser;
-  replParser = example.parser;
   code.value = example.code;
   commandHistory.value = [
     { type: "output", text: `Yukigo REPL v0.1.0 — ${lang.charAt(0).toUpperCase() + lang.slice(1)} loaded` },
@@ -173,7 +171,7 @@ function executeCommand() {
         lazyLoading: true,
         debug: true,
       });
-      const expression = replParser.parse(commandText);
+      const expression = parser.parseExpression(commandText);
       output = interpreter.evaluate(expression[0]);
     } catch (err) {
       output = err.toString();

--- a/packages/yukigo-ast/src/globals/generics.ts
+++ b/packages/yukigo-ast/src/globals/generics.ts
@@ -1405,6 +1405,7 @@ export type AST = Statement[];
 export interface YukigoParser {
   errors?: string[];
   parse: (code: string) => AST;
+  parseExpression: (code: string) => Expression;
 }
 
 /* export interface Match {

--- a/packages/yukigo-haskell-parser/src/index.ts
+++ b/packages/yukigo-haskell-parser/src/index.ts
@@ -2,54 +2,84 @@ import grammar from "./parser/grammar.js";
 import nearley from "nearley";
 import { groupFunctionDeclarations } from "./utils/helpers.js";
 import { TypeChecker } from "./typechecker/checker.js";
-import { AST, YukigoParser } from "yukigo-ast";
+import { AST, Expression, YukigoParser } from "yukigo-ast";
 import { inspect } from "util";
 import { preprocessor } from "./parser/layoutPreprocessor.js";
 import { preludeCode } from "./prelude.js";
+import { Token } from "moo";
+
+class UnexpectedToken extends Error {
+  constructor(token: Token) {
+    super(
+      `Parser: Unexpected '${token.type}' token '${token.value}' at line ${token.line} col ${token.col}.`
+    );
+  }
+}
+class AmbiguityError extends Error {
+  constructor(amountAST: number) {
+    super(
+      `Parser: Too much ambiguity. ${amountAST} ASTs parsed. Output not generated.`
+    );
+  }
+}
+class TypeError extends Error {
+  constructor(errors: string[]) {
+    super(`Found type errors.\n\t-${errors.join("\n\t-")}`);
+  }
+}
+
+export type HaskellConfig = {
+  typecheck: boolean;
+};
+
+const HaskellDefaultConfig = {
+  typecheck: true,
+};
 
 export class YukigoHaskellParser implements YukigoParser {
   public errors: string[] = [];
-  private prelude: string;
-  constructor(prelude?: string) {
+  private prelude: AST;
+  private config: HaskellConfig;
+  constructor(
+    prelude: string = preludeCode,
+    config: HaskellConfig = HaskellDefaultConfig
+  ) {
     this.errors = [];
-    this.prelude = prelude ?? preludeCode;
+    this.prelude = this.feedParser(prelude);
+    this.config = config;
   }
 
   public parse(code: string): AST {
     const processedCode = preprocessor(code);
-    const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
-    try {
-      parser.feed(this.prelude + "\n\n" + processedCode);
-      parser.finish();
-    } catch (error) {
-      console.log(error)
-      if ("token" in error) {
-        const token = error.token;
-        const message = `Parser: Unexpected '${token.type}' token '${token.value}' at line ${token.line} col ${token.col}.`;
-        this.errors.push(message);
-        throw Error(message);
-      }
-      throw error;
-    }
-    if (parser.results.length > 1) {
-      const msg = `Parser: Too much ambiguity. ${parser.results.length} ASTs parsed. Output not generated.`;
-      this.errors.push(msg);
-      throw Error(msg);
-    }
-    if (parser.results.length == 0) {
-      this.errors.push("Parser did not generate an AST.");
-      throw Error("Parser did not generate an AST.");
-    }
-    const ast = groupFunctionDeclarations(parser.results[0]);
-    try {
+    const result = this.feedParser(processedCode);
+    const ast = groupFunctionDeclarations(this.prelude.concat(result));
+    if (this.config.typecheck) {
       const typeChecker = new TypeChecker();
       const errors = typeChecker.check(ast);
       if (errors.length > 0) {
         this.errors.push(...errors);
+        throw new TypeError(errors);
       }
-    } catch (error) {
-      console.log(error);
     }
     return ast;
+  }
+  public parseExpression(code: string): Expression {
+    const processedCode = preprocessor(code);
+    const expr = this.feedParser(processedCode);
+    return expr;
+  }
+  private feedParser(code: string): any {
+    const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
+    try {
+      parser.feed(code);
+      parser.finish();
+    } catch (error) {
+      if ("token" in error) throw new UnexpectedToken(error.token);
+      throw error;
+    }
+    const { results } = parser;
+    if (results.length > 1) throw new AmbiguityError(results.length);
+    if (results.length == 0) return [];
+    return results[0];
   }
 }

--- a/packages/yukigo-haskell-parser/tests/parser.spec.ts
+++ b/packages/yukigo-haskell-parser/tests/parser.spec.ts
@@ -52,7 +52,7 @@ assert.deepEqual = function (actual: any, expected: any, ...args: any[]) {
 describe("Parser Tests", () => {
   let parser: YukigoHaskellParser;
   beforeEach(() => {
-    parser = new YukigoHaskellParser("");
+    parser = new YukigoHaskellParser("", { typecheck: false });
   });
   it("parses boolean expressions", () => {
     const returnExpression = new Return(
@@ -92,7 +92,7 @@ describe("Parser Tests", () => {
     assert.deepEqual(parser.parse('f "hello world" = 1'), [
       new Function(new SymbolPrimitive("f"), [
         new Equation(
-          [new LiteralPattern(new StringPrimitive('hello world'))],
+          [new LiteralPattern(new StringPrimitive("hello world"))],
           new UnguardedBody(new Sequence([returnExpression])),
           returnExpression
         ),

--- a/packages/yukigo-haskell-parser/tests/typechecker.spec.ts
+++ b/packages/yukigo-haskell-parser/tests/typechecker.spec.ts
@@ -19,7 +19,7 @@ describe("TypeChecker Tests", () => {
   });
   it("detects incorrect usage of logical operation", () => {
     const code = `f :: String -> Bool -> Bool\r\nf x y = x && y`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.include(
       parser.errors,
       "Type error in 'f': Left side of And must be a boolean"
@@ -32,7 +32,7 @@ describe("TypeChecker Tests", () => {
   });
   it("detects return type mismatch", () => {
     const code = `toInt :: String -> Int\r\ntoInt s = s`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
 
     assert.include(
       parser.errors,
@@ -42,7 +42,7 @@ describe("TypeChecker Tests", () => {
 
   it("detects parameter type mismatch", () => {
     const code = `head' :: [Int] -> Int\r\nhead' (x:_) = x\r\nhead' [] = 0\r\nfirst :: [Char] -> Char\r\nfirst list = head' list`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.include(
       parser.errors,
       "Type error in 'first': Cannot apply [YuChar] to type [YuNumber] -> YuNumber"
@@ -50,7 +50,7 @@ describe("TypeChecker Tests", () => {
   });
   it("detects bad application of parameters in tuple", () => {
     const code = `f :: (Int, Int, Int) -> Int\r\nf (x,y,z)= maximum (x y z) - maximum (x y z)`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.include(
       parser.errors,
       "Type error in 'f': Cannot apply YuNumber to type YuNumber"
@@ -63,7 +63,7 @@ describe("TypeChecker Tests", () => {
   });
   it("detects incorrect concat operation of lists", () => {
     const code = `f = [2] ++ ["4"]`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.include(
       parser.errors,
       "Type error in 'f': Concat operation requires both operands to be lists of the same type."
@@ -100,7 +100,7 @@ describe("TypeChecker Tests", () => {
   });
   it("detects duplicate variable with list pattern", () => {
     const code = `f [y] y = y`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.include(
       parser.errors,
       "Type error in 'f': Duplicate variable name 'y'"
@@ -113,7 +113,7 @@ describe("TypeChecker Tests", () => {
   });
   it("detects incorrect polymorphic usage", () => {
     const code = `id :: a -> a\nid x = x + "not polymorphic"`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
 
     assert.include(
       parser.errors,
@@ -123,12 +123,12 @@ describe("TypeChecker Tests", () => {
 
   it("validates typeclass constraints", () => {
     const code = `f :: Num a => a -> a\r\nf x = x + 2`;
-    const ast = parser.parse(code);
+    parser.parse(code);
     assert.isEmpty(parser.errors, "Should accept valid Show constraint");
   });
   it("detects incorrect typeclass constraints", () => {
     const code = `f :: Num a => a -> a\r\nf x = x ++ "2"`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.include(
       parser.errors,
       "Type error in 'f': Type 'YuString' is not an instance of 'Num'"
@@ -136,7 +136,7 @@ describe("TypeChecker Tests", () => {
   });
   it("detects arithmetic type errors", () => {
     const code = `invalidAdd = "text" + 42`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
 
     assert.include(
       parser.errors,
@@ -152,7 +152,7 @@ describe("TypeChecker Tests", () => {
 
   it("detects higher-order function misuse", () => {
     const code = `apply :: (Int -> String) -> Int -> String\napply f x = f (x + "error")`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
 
     assert.include(
       parser.errors,
@@ -168,7 +168,7 @@ describe("TypeChecker Tests", () => {
 
   it("detects recursive type errors", () => {
     const code = `badFactorial :: Int -> String\nbadFactorial 0 = "1"\nbadFactorial n = n * badFactorial (n - 1)`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.include(
       parser.errors,
       "Type error in 'badFactorial': Right operand of Multiply must be a number"
@@ -183,7 +183,7 @@ describe("TypeChecker Tests", () => {
 
   it("detects data constructor type errors", () => {
     const code = `data Foo = Bar String | Baz\r\nf :: Int -> Foo\r\nf x = Bar x`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.include(
       parser.errors,
       "Type error in 'f': Cannot apply YuNumber to type YuString -> Foo t657"
@@ -196,7 +196,7 @@ describe("TypeChecker Tests", () => {
   });
   it("detects incorrect usage of map", () => {
     const code = `f :: [Int] -> [Int]\nf xs = map (\\x -> x ++ "2") xs`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.include(
       parser.errors,
       "Type error in 'f': Cannot unify YuString with YuNumber"
@@ -204,7 +204,7 @@ describe("TypeChecker Tests", () => {
   });
   it("detects incorrect arity in map", () => {
     const code = `f :: [Int] -> [Int]\nf xs = map (\\x y -> x + 2) xs`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.include(
       parser.errors,
       "Type error in 'f': Cannot unify t659 -> YuNumber with YuNumber"
@@ -217,7 +217,7 @@ describe("TypeChecker Tests", () => {
   });
   it("detects incorrect usage of filter", () => {
     const code = `f :: [Int] -> [Int]\nf xs = filter (\\x -> x ++ "2") xs`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.include(
       parser.errors,
       "Type error in 'f': Cannot apply t657 -> YuString to type (t656 -> YuBoolean) -> [t656] -> [t656]"
@@ -225,7 +225,7 @@ describe("TypeChecker Tests", () => {
   });
   it("handles multiple type errors", () => {
     const code = `f :: Int -> String\nf x = x + "error"\ng = 42`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.equal(parser.errors.length, 1);
     assert.include(
       parser.errors,
@@ -234,7 +234,7 @@ describe("TypeChecker Tests", () => {
   });
   it("detects incorrect use of maximum with not ordenable type", () => {
     const code = `f :: [Boolean] -> Boolean\nf xs = maximum xs`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.include(
       parser.errors,
       "Type error in 'f': Type 'YuBoolean' is not an instance of 'Ord'"
@@ -247,7 +247,7 @@ describe("TypeChecker Tests", () => {
   });
   it("detects incorrect use of arithmetic operator round", () => {
     const code = `f :: String -> Int\nf x = round x`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.include(
       parser.errors,
       "Type error in 'f': Operand of Round must be a number"
@@ -265,7 +265,7 @@ describe("TypeChecker Tests", () => {
   });
   it("detects invalid type with where clause", () => {
     const code = `areaOfCircle :: Int -> Int\r\nareaOfCircle radius = pi * radius_squared\n where\n      pi = "3.14159"\n      radius_squared = radius * radius`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.include(
       parser.errors,
       "Type error in 'areaOfCircle': Left operand of Multiply must be a number"
@@ -278,7 +278,7 @@ describe("TypeChecker Tests", () => {
   });
   it("detects incorrect usage of let...in expression", () => {
     const code = `hypotenuse a b = let a_sq = a * a; b_sq = b * b; sum_sq = a_sq + b_sq in sum_sq ++ "a string"`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.include(
       parser.errors,
       "Type error in 'hypotenuse': String operation requires string operands"
@@ -286,7 +286,7 @@ describe("TypeChecker Tests", () => {
   });
   it("detects incorrect usage of let...in expression", () => {
     const code = `hypotenuse a b = let a_sq = a * a; b_sq = b * b; sum_sq = a_sq ++ b_sq in sqrt sum_sq`;
-    parser.parse(code);
+    assert.throw(() => parser.parse(code));
     assert.include(
       parser.errors,
       "Type error in 'hypotenuse': Type error in 'sum_sq': Left operand of concat must be a list, got YuNumber"

--- a/packages/yukigo-prolog-parser/src/parser/parser.ts
+++ b/packages/yukigo-prolog-parser/src/parser/parser.ts
@@ -1,35 +1,58 @@
-import { AST, YukigoParser } from "yukigo-ast";
+import { AST, Expression, YukigoParser } from "yukigo-ast";
 import nearley from "nearley";
 import grammar from "./grammar.js";
+import { Token } from "moo";
+import { stdCode } from "../std.js";
+
+class UnexpectedToken extends Error {
+  constructor(token: Token) {
+    super(
+      `Parser: Unexpected '${token.type}' token '${token.value}' at line ${token.line} col ${token.col}.`
+    );
+  }
+}
+class AmbiguityError extends Error {
+  constructor(amountAST: number) {
+    super(
+      `Parser: Too much ambiguity. ${amountAST} ASTs parsed. Output not generated.`
+    );
+  }
+}
+
+export type HaskellConfig = {
+  typecheck: boolean;
+};
 
 export class YukigoPrologParser implements YukigoParser {
   public errors: string[] = [];
+  private std: AST;
+  constructor(
+    std: string = stdCode,
+  ) {
+    this.errors = [];
+    this.std = this.feedParser(std);
+  }
   public parse(code: string): AST {
+    const result = this.feedParser(code);
+    const ast = this.std.concat(result);
+    return ast;
+  }
+  public parseExpression(code: string): Expression {
+    const expr = this.feedParser(code);
+    return expr;
+  }
+  private feedParser(code: string): any {
     const parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
     try {
       parser.feed(code);
       parser.finish();
     } catch (error) {
-      console.log(error)
-      if ("token" in error) throw Error(error);
-      const token = error.token;
-      const message = `Unexpected '${token.type}' token '${token.value}' at line ${token.line} col ${token.col}.`;
-      this.errors.push(message);
-      throw Error(message);
+      if ("token" in error) throw new UnexpectedToken(error.token);
+      throw error;
     }
-    if (parser.results.length > 1) {
-      this.errors.push(
-        `Too much ambiguity. ${parser.results.length} ASTs. Output not generated.`
-      );
-      throw Error(
-        `Too much ambiguity. ${parser.results.length} ASTs. Output not generated.`
-      );
-    }
-    if (parser.results.length == 0) {
-      this.errors.push("Parser did not generate an AST.");
-      throw Error("Parser did not generate an AST.");
-    }
-
-    return parser.results[0];
+    const { results } = parser;
+    if (results.length > 1) throw new AmbiguityError(results.length);
+    if (results.length == 0) return [];
+    return results[0];
   }
 }

--- a/packages/yukigo-prolog-parser/src/std.ts
+++ b/packages/yukigo-prolog-parser/src/std.ts
@@ -1,3 +1,4 @@
+export const stdCode = `
 % between(+Low, +High, ?Value)
 % True if Low =< Value =< High (assuming integers)
 between(Low, High, Low) :- Low =< High.
@@ -117,3 +118,4 @@ exclude(Pred, [H|T], Rest) :-
     ;   Rest = [H|Rest2],
         exclude(Pred, T, Rest2)
     ).
+`

--- a/packages/yukigo-prolog-parser/tests/parser.spec.ts
+++ b/packages/yukigo-prolog-parser/tests/parser.spec.ts
@@ -27,6 +27,7 @@ import {
   WildcardPattern,
   YukigoParser,
 } from "yukigo-ast";
+import { stdCode } from "../src/std.js";
 const _deepEqual = assert.deepEqual;
 assert.deepEqual = function (actual: any, expected: any, ...args: any[]) {
   function stripLoc(obj: any): any {
@@ -45,11 +46,11 @@ assert.deepEqual = function (actual: any, expected: any, ...args: any[]) {
 describe("Parser Test", () => {
   let parser: YukigoParser;
   beforeEach(() => {
-    parser = new YukigoPrologParser();
+    parser = new YukigoPrologParser("");
   });
   it("std.pl", () => {
     assert.doesNotThrow(() =>
-      parser.parse(readFileSync("./src/std.pl").toString())
+      parser.parse(stdCode)
     );
   });
   it("simplest fact/0", () => {

--- a/packages/yukigo-wollok-parser/src/index.ts
+++ b/packages/yukigo-wollok-parser/src/index.ts
@@ -1,6 +1,15 @@
-import { AST, YukigoParser } from "yukigo-ast";
+import { AST, Expression, YukigoParser } from "yukigo-ast";
 import { parse } from "wollok-ts";
 import { WollokToYukigoTransformer } from "./transformer.js";
+import { Token } from "moo";
+
+class UnexpectedToken extends Error {
+  constructor(line, column, expectation) {
+    super(
+      `Parse error at line ${line} column ${column}: expected ${expectation}.`
+    );
+  }
+}
 
 export class YukigoWollokParser implements YukigoParser {
   public errors: string[] = [];
@@ -13,13 +22,27 @@ export class YukigoWollokParser implements YukigoParser {
     if (parserResult.status === false) {
       const { index, expected } = parserResult;
       const expectation = expected.join(" or ");
+      throw new UnexpectedToken(index.line, index.column, expectation);
+    }
+    const resultAST = parserResult.value;
+
+    const transformer = new WollokToYukigoTransformer();
+    const yukigoAst = transformer.transform(resultAST);
+
+    return yukigoAst;
+  }
+  public parseExpression(code: string): Expression {
+    const parserResult = parse.File("example").parse(code);
+    if (parserResult.status === false) {
+      const { index, expected } = parserResult;
+      const expectation = expected.join(" or ");
       const message = `Parse error at line ${index.line} column ${index.column}: expected ${expectation}.`;
       throw new Error(message);
     }
     const resultAST = parserResult.value;
 
     const transformer = new WollokToYukigoTransformer();
-    const yukigoAst = transformer.transform(resultAST);
+    const yukigoAst = transformer.transformExpr(resultAST);
 
     return yukigoAst;
   }

--- a/packages/yukigo-wollok-parser/src/transformer.ts
+++ b/packages/yukigo-wollok-parser/src/transformer.ts
@@ -78,6 +78,10 @@ export class WollokToYukigoTransformer {
     const result = this.visit(root);
     return Array.isArray(result) ? result : [result];
   }
+  public transformExpr(root: Package): Yu.Expression {
+    const result = this.visit(root);
+    return result;
+  }
 
   private visit(node: Node): any {
     const nodeType = node.constructor ? node.constructor.name : "Unknown";


### PR DESCRIPTION
Added parseExpression to YukigoParser interface and removed replParser from CodePlayground component