### PR TITLE
Update Haskell and Prolog parsers to support testing nodes

### DIFF
--- a/packages/yukigo-haskell-parser/src/index.ts
+++ b/packages/yukigo-haskell-parser/src/index.ts
@@ -72,7 +72,7 @@ export class YukigoHaskellParser implements YukigoParser {
       parser.feed(code);
       parser.finish();
     } catch (error) {
-      if ("token" in error) throw new UnexpectedToken(error.token);
+      if ("token" in error && error.token) throw new UnexpectedToken(error.token);
       throw error;
     }
     const { results } = parser;

--- a/packages/yukigo-haskell-parser/src/typechecker/DeclarationCollector.ts
+++ b/packages/yukigo-haskell-parser/src/typechecker/DeclarationCollector.ts
@@ -4,6 +4,9 @@ import {
   TypeAlias,
   TypeSignature,
   Visitor,
+  TestGroup,
+  Test,
+  Assert,
 } from "yukigo-ast";
 import {
   functionType,
@@ -97,6 +100,15 @@ export class DeclarationCollectorVisitor implements Visitor<void> {
       body: type,
       constraints,
     });
+  }
+  visitTestGroup(node: TestGroup): void {
+    node.group.accept(this);
+  }
+  visitTest(node: Test): void {
+    node.body.accept(this);
+  }
+  visitAssert(node: Assert): void {
+    // assertions don't contain declarations
   }
   visit(node: ASTNode): void {
     node.accept(this);

--- a/packages/yukigo-haskell-parser/src/utils/types.ts
+++ b/packages/yukigo-haskell-parser/src/utils/types.ts
@@ -26,6 +26,11 @@ export const keywords = [
   "qualified",
   "hiding",
   "foreign",
+  "describe",
+  "it",
+  "shouldBe",
+  "shouldNotBe",
+  "shouldSatisfy"
 ];
 
 export const typeMappings: { [key: string]: YukigoPrimitive } = {

--- a/packages/yukigo-haskell-parser/tests/hspec.spec.ts
+++ b/packages/yukigo-haskell-parser/tests/hspec.spec.ts
@@ -1,0 +1,77 @@
+import { expect } from "chai";
+import { YukigoHaskellParser } from "../src/index.js";
+import {
+  TestGroup,
+  Test,
+  Assert,
+  Equality,
+  Truth,
+  NumberPrimitive,
+  SymbolPrimitive,
+  Application,
+  StringPrimitive,
+  BooleanPrimitive
+} from "yukigo-ast";
+
+describe("HSpec Parsing", () => {
+  const parser = new YukigoHaskellParser("");
+
+  it("should parse describe and it blocks", () => {
+    const code = `
+describe "Math" do
+  it "adds 1 and 1" do
+    (1 + 1) shouldBe 2
+`;
+    const ast = parser.parse(code);
+    expect(ast).to.have.lengthOf(1);
+    expect(ast[0]).to.be.instanceOf(TestGroup);
+    
+    const group = ast[0] as TestGroup;
+    expect(group.name).to.be.instanceOf(StringPrimitive);
+    expect((group.name as StringPrimitive).value).to.equal("Math");
+    
+    expect(group.group.statements).to.have.lengthOf(1);
+    expect(group.group.statements[0]).to.be.instanceOf(Test);
+    
+    const test = group.group.statements[0] as Test;
+    expect(test.name).to.be.instanceOf(StringPrimitive);
+    expect((test.name as StringPrimitive).value).to.equal("adds 1 and 1");
+    
+    expect(test.body.statements).to.have.lengthOf(1);
+    expect(test.body.statements[0]).to.be.instanceOf(Assert);
+    
+    const assert = test.body.statements[0] as Assert;
+    expect(assert.negated).to.be.instanceOf(BooleanPrimitive);
+    expect((assert.negated as BooleanPrimitive).value).to.be.false;
+    expect(assert.body).to.be.instanceOf(Equality);
+    
+    const equality = assert.body as Equality;
+    expect(equality.expected).to.be.instanceOf(NumberPrimitive);
+    expect((equality.expected as NumberPrimitive).value).to.equal(2);
+  });
+
+  it("should parse shouldNotBe", () => {
+    const code = `it "negation" do 1 shouldNotBe 2`;
+    const ast = parser.parse(code);
+    const test = ast[0] as Test;
+    const assert = test.body.statements[0] as Assert;
+    expect((assert.negated as BooleanPrimitive).value).to.be.true;
+    expect(assert.body).to.be.instanceOf(Equality);
+  });
+
+  it("should parse shouldSatisfy", () => {
+    const code = `it "satisfy" do 5 shouldSatisfy odd`;
+    const ast = parser.parse(code);
+    const test = ast[0] as Test;
+    const assert = test.body.statements[0] as Assert;
+    expect(assert.body).to.be.instanceOf(Truth);
+    
+    const truth = assert.body as Truth;
+    expect(truth.body).to.be.instanceOf(Application);
+    const app = truth.body as Application;
+    expect(app.functionExpr).to.be.instanceOf(SymbolPrimitive);
+    expect((app.functionExpr as SymbolPrimitive).value).to.equal("odd");
+    expect(app.parameter).to.be.instanceOf(NumberPrimitive);
+    expect((app.parameter as NumberPrimitive).value).to.equal(5);
+  });
+});

--- a/packages/yukigo-haskell-parser/tests/parser.spec.ts
+++ b/packages/yukigo-haskell-parser/tests/parser.spec.ts
@@ -81,7 +81,7 @@ describe("Parser Tests", () => {
     assert.deepEqual(parser.parse("f 'a' = 1"), [
       new Function(new SymbolPrimitive("f"), [
         new Equation(
-          [new LiteralPattern(new CharPrimitive("'a'"))],
+          [new LiteralPattern(new CharPrimitive("a"))],
           new UnguardedBody(new Sequence([returnExpression])),
           returnExpression
         ),
@@ -288,10 +288,15 @@ describe("Parser Tests", () => {
     ]);
   });
   it("parses chars and single char strings differently", () => {
-    assert.notDeepEqual(parser.parse('x = "a"'), parser.parse("x = 'a'"));
+    const stringAst: any = parser.parse('x = "a"');
+    const charAst: any = parser.parse("x = 'a'");
+    const stringExpr = stringAst[0].equations[0].returnExpr.body;
+    const charExpr = charAst[0].equations[0].returnExpr.body;
+    assert.instanceOf(stringExpr, StringPrimitive);
+    assert.instanceOf(charExpr, CharPrimitive);
   });
   it("parses chars as YuChars", () => {
-    const returnExpression = new Return(new CharPrimitive("'a'"));
+    const returnExpression = new Return(new CharPrimitive("a"));
     assert.deepEqual(parser.parse("x = 'a'"), [
       new Function(new SymbolPrimitive("x"), [
         new Equation(

--- a/packages/yukigo-haskell-parser/tsconfig.json
+++ b/packages/yukigo-haskell-parser/tsconfig.json
@@ -10,7 +10,8 @@
     "allowSyntheticDefaultImports": true,
     "sourceMap": true,
     "forceConsistentCasingInFileNames": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "composite": true
   },
   "include": ["src"],
   "exclude": [

--- a/packages/yukigo-prolog-parser/src/parser/lexer.ts
+++ b/packages/yukigo-prolog-parser/src/parser/lexer.ts
@@ -30,7 +30,8 @@ export const PrologLexerConfig = {
   atom: {
     match: /[a-z!][a-zA-Z0-9_\u00C0-\u00FF]*/,
     type: moo.keywords({
-      primitiveOperator: ["round", "abs", "sqrt", "call"],
+      primitiveOperator: ["round", "abs", "sqrt", "call", "max", "assertion"],
+      testKeyword: ["test"],
     }),
   },
   NL: { match: /\r?\n/, lineBreaks: true },

--- a/packages/yukigo-prolog-parser/src/std.ts
+++ b/packages/yukigo-prolog-parser/src/std.ts
@@ -118,4 +118,15 @@ exclude(Pred, [H|T], Rest) :-
     ;   Rest = [H|Rest2],
         exclude(Pred, T, Rest2)
     ).
+
+% Arithmetic predicates
+abs(X, Y) :- Y is abs(X).
+round(X, Y) :- Y is round(X).
+sqrt(X, Y) :- Y is sqrt(X).
+
+
+max_list([X], X).
+max_list([H|T], Max) :-
+    max_list(T, MaxTail),
+    Max is max(H, MaxTail).
 `

--- a/packages/yukigo-prolog-parser/tests/parser.spec.ts
+++ b/packages/yukigo-prolog-parser/tests/parser.spec.ts
@@ -32,6 +32,7 @@ import {
   YukigoParser,
   Equation,
   UnguardedBody,
+  LogicConstraint,
 } from "yukigo-ast";
 import { stdCode } from "../src/std.js";
 const _deepEqual = assert.deepEqual;
@@ -41,7 +42,7 @@ assert.deepEqual = function (actual: any, expected: any, ...args: any[]) {
     if (obj && typeof obj === "object") {
       const { loc, ...rest } = obj;
       return Object.fromEntries(
-        Object.entries(rest).map(([k, v]) => [k, stripLoc(v)])
+        Object.entries(rest).map(([k, v]) => [k, stripLoc(v)]),
       );
     }
     return obj;
@@ -132,8 +133,8 @@ describe("Parser Test", () => {
         new Equation(
           [new LiteralPattern(new SymbolPrimitive("bar"))],
           new UnguardedBody(
-            new Sequence([new Exist(new SymbolPrimitive("foo"), [])])
-          )
+            new Sequence([new Exist(new SymbolPrimitive("foo"), [])]),
+          ),
         ),
       ]),
     ]);
@@ -144,8 +145,8 @@ describe("Parser Test", () => {
         new Equation(
           [],
           new UnguardedBody(
-            new Sequence([new Exist(new SymbolPrimitive("foo"), [])])
-          )
+            new Sequence([new Exist(new SymbolPrimitive("foo"), [])]),
+          ),
         ),
       ]),
     ]);
@@ -153,7 +154,7 @@ describe("Parser Test", () => {
   it("rules with withiespaces", () => {
     assert.deepEqual(
       parser.parse("baz:-foo(X), baz(X,Y)."),
-      parser.parse("baz :- foo( X) ,baz( X , Y) .")
+      parser.parse("baz :- foo( X) ,baz( X , Y) ."),
     );
   });
   it("rules with bang", () => {
@@ -165,8 +166,8 @@ describe("Parser Test", () => {
             new Sequence([
               new Exist(new SymbolPrimitive("fail"), []),
               new Exist(new SymbolPrimitive("!"), []),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -181,8 +182,8 @@ describe("Parser Test", () => {
               new Exist(new SymbolPrimitive("foo"), [
                 new LiteralPattern(new SymbolPrimitive("bar")),
               ]),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -225,8 +226,8 @@ describe("Parser Test", () => {
                 new Exist(new SymbolPrimitive("foo"), [
                   new LiteralPattern(new SymbolPrimitive("bar")),
                 ]),
-              ])
-            )
+              ]),
+            ),
           ),
         ]),
         new Rule(new SymbolPrimitive("foo"), [
@@ -237,11 +238,11 @@ describe("Parser Test", () => {
                 new Exist(new SymbolPrimitive("bar"), [
                   new LiteralPattern(new SymbolPrimitive("bar")),
                 ]),
-              ])
-            )
+              ]),
+            ),
           ),
         ]),
-      ]
+      ],
     );
   });
   it("simplest rule/2 with condition/2", () => {
@@ -258,8 +259,8 @@ describe("Parser Test", () => {
                 new LiteralPattern(new SymbolPrimitive("bar")),
                 new LiteralPattern(new SymbolPrimitive("goo")),
               ]),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -271,13 +272,15 @@ describe("Parser Test", () => {
           [new VariablePattern(new SymbolPrimitive("X"))],
           new UnguardedBody(
             new Sequence([
-              new Not([
-                new Exist(new SymbolPrimitive("bar"), [
-                  new VariablePattern(new SymbolPrimitive("X")),
+              new Not(
+                new Sequence([
+                  new Exist(new SymbolPrimitive("bar"), [
+                    new VariablePattern(new SymbolPrimitive("X")),
+                  ]),
                 ]),
-              ]),
-            ])
-          )
+              ),
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -289,13 +292,13 @@ describe("Parser Test", () => {
           [new VariablePattern(new SymbolPrimitive("X"))],
           new UnguardedBody(
             new Sequence([
-              new Not([
+              new Not(
                 new Exist(new SymbolPrimitive("bar"), [
                   new VariablePattern(new SymbolPrimitive("X")),
                 ]),
-              ]),
-            ])
-          )
+              ),
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -307,7 +310,7 @@ describe("Parser Test", () => {
           [new VariablePattern(new SymbolPrimitive("X"))],
           new UnguardedBody(
             new Sequence([
-              new Not([
+              new Not(
                 new Sequence([
                   new Exist(new SymbolPrimitive("bar"), [
                     new VariablePattern(new SymbolPrimitive("X")),
@@ -316,9 +319,9 @@ describe("Parser Test", () => {
                     new VariablePattern(new SymbolPrimitive("Y")),
                   ]),
                 ]),
-              ]),
-            ])
-          )
+              ),
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -337,10 +340,10 @@ describe("Parser Test", () => {
 
                 new Exist(new SymbolPrimitive("bar"), [
                   new VariablePattern(new SymbolPrimitive("X")),
-                ])
+                ]),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -358,10 +361,10 @@ describe("Parser Test", () => {
                   new VariablePattern(new SymbolPrimitive("X")),
                   new VariablePattern(new SymbolPrimitive("Y")),
                 ]),
-                new Exist(new SymbolPrimitive("Z"), [])
+                new VariablePattern(new SymbolPrimitive("Z")),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -373,13 +376,15 @@ describe("Parser Test", () => {
           [new VariablePattern(new SymbolPrimitive("X"))],
           new UnguardedBody(
             new Sequence([
-              new ComparisonOperation(
-                "GreaterThan",
-                new SymbolPrimitive("X"),
-                new NumberPrimitive(4)
+              new LogicConstraint(
+                new ComparisonOperation(
+                  "GreaterThan",
+                  new SymbolPrimitive("X"),
+                  new NumberPrimitive(4),
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -391,13 +396,15 @@ describe("Parser Test", () => {
           [new VariablePattern(new SymbolPrimitive("X"))],
           new UnguardedBody(
             new Sequence([
-              new ComparisonOperation(
-                "LessThan",
-                new SymbolPrimitive("X"),
-                new NumberPrimitive(4)
+              new LogicConstraint(
+                new ComparisonOperation(
+                  "LessThan",
+                  new SymbolPrimitive("X"),
+                  new NumberPrimitive(4),
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -409,13 +416,15 @@ describe("Parser Test", () => {
           [new VariablePattern(new SymbolPrimitive("X"))],
           new UnguardedBody(
             new Sequence([
-              new ComparisonOperation(
-                "GreaterOrEqualThan",
-                new SymbolPrimitive("X"),
-                new NumberPrimitive(4)
+              new LogicConstraint(
+                new ComparisonOperation(
+                  "GreaterOrEqualThan",
+                  new SymbolPrimitive("X"),
+                  new NumberPrimitive(4),
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -427,13 +436,15 @@ describe("Parser Test", () => {
           [new VariablePattern(new SymbolPrimitive("X"))],
           new UnguardedBody(
             new Sequence([
-              new ComparisonOperation(
-                "LessOrEqualThan",
-                new SymbolPrimitive("X"),
-                new NumberPrimitive(4)
+              new LogicConstraint(
+                new ComparisonOperation(
+                  "LessOrEqualThan",
+                  new SymbolPrimitive("X"),
+                  new NumberPrimitive(4),
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -445,13 +456,15 @@ describe("Parser Test", () => {
           [new VariablePattern(new SymbolPrimitive("X"))],
           new UnguardedBody(
             new Sequence([
-              new ComparisonOperation(
-                "NotSame",
-                new SymbolPrimitive("X"),
-                new NumberPrimitive(4)
+              new LogicConstraint(
+                new ComparisonOperation(
+                  "NotSame",
+                  new SymbolPrimitive("X"),
+                  new NumberPrimitive(4),
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -463,13 +476,15 @@ describe("Parser Test", () => {
           [new VariablePattern(new SymbolPrimitive("X"))],
           new UnguardedBody(
             new Sequence([
-              new UnifyOperation(
-                "Unify",
-                new SymbolPrimitive("X"),
-                new NumberPrimitive(4)
+              new LogicConstraint(
+                new UnifyOperation(
+                  "Unify",
+                  new SymbolPrimitive("X"),
+                  new NumberPrimitive(4),
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -481,13 +496,15 @@ describe("Parser Test", () => {
           [new VariablePattern(new SymbolPrimitive("X"))],
           new UnguardedBody(
             new Sequence([
-              new AssignOperation(
-                "Assign",
-                new SymbolPrimitive("X"),
-                new NumberPrimitive(4)
+              new LogicConstraint(
+                new AssignOperation(
+                  "Assign",
+                  new SymbolPrimitive("X"),
+                  new NumberPrimitive(4),
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -499,13 +516,15 @@ describe("Parser Test", () => {
           [new VariablePattern(new SymbolPrimitive("X"))],
           new UnguardedBody(
             new Sequence([
-              new AssignOperation(
-                "Assign",
-                new SymbolPrimitive("X"),
-                new NumberPrimitive(4)
+              new LogicConstraint(
+                new AssignOperation(
+                  "Assign",
+                  new SymbolPrimitive("X"),
+                  new NumberPrimitive(4),
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -530,17 +549,19 @@ describe("Parser Test", () => {
           ],
           new UnguardedBody(
             new Sequence([
-              new AssignOperation(
-                "Assign",
-                new SymbolPrimitive("X"),
-                new ArithmeticBinaryOperation(
-                  "Minus",
-                  new SymbolPrimitive("Y"),
-                  new NumberPrimitive(5)
-                )
+              new LogicConstraint(
+                new AssignOperation(
+                  "Assign",
+                  new SymbolPrimitive("X"),
+                  new ArithmeticBinaryOperation(
+                    "Minus",
+                    new SymbolPrimitive("Y"),
+                    new NumberPrimitive(5),
+                  ),
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -555,17 +576,19 @@ describe("Parser Test", () => {
           ],
           new UnguardedBody(
             new Sequence([
-              new AssignOperation(
-                "Assign",
-                new SymbolPrimitive("X"),
-                new ArithmeticBinaryOperation(
-                  "Plus",
-                  new SymbolPrimitive("Y"),
-                  new NumberPrimitive(5)
-                )
+              new LogicConstraint(
+                new AssignOperation(
+                  "Assign",
+                  new SymbolPrimitive("X"),
+                  new ArithmeticBinaryOperation(
+                    "Plus",
+                    new SymbolPrimitive("Y"),
+                    new NumberPrimitive(5),
+                  ),
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -580,13 +603,15 @@ describe("Parser Test", () => {
           ],
           new UnguardedBody(
             new Sequence([
-              new ComparisonOperation(
-                "Equal",
-                new SymbolPrimitive("X"),
-                new SymbolPrimitive("Y")
+              new LogicConstraint(
+                new ComparisonOperation(
+                  "Equal",
+                  new SymbolPrimitive("X"),
+                  new SymbolPrimitive("Y"),
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -601,13 +626,15 @@ describe("Parser Test", () => {
           ],
           new UnguardedBody(
             new Sequence([
-              new ComparisonOperation(
-                "Same",
-                new SymbolPrimitive("X"),
-                new SymbolPrimitive("Y")
+              new LogicConstraint(
+                new ComparisonOperation(
+                  "Same",
+                  new SymbolPrimitive("X"),
+                  new SymbolPrimitive("Y"),
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -622,21 +649,23 @@ describe("Parser Test", () => {
           ],
           new UnguardedBody(
             new Sequence([
-              new AssignOperation(
-                "Assign",
-                new SymbolPrimitive("X"),
-                new ArithmeticBinaryOperation(
-                  "Plus",
+              new LogicConstraint(
+                new AssignOperation(
+                  "Assign",
+                  new SymbolPrimitive("X"),
                   new ArithmeticBinaryOperation(
-                    "Divide",
-                    new SymbolPrimitive("Y"),
-                    new NumberPrimitive(5)
+                    "Plus",
+                    new ArithmeticBinaryOperation(
+                      "Divide",
+                      new SymbolPrimitive("Y"),
+                      new NumberPrimitive(5),
+                    ),
+                    new NumberPrimitive(20),
                   ),
-                  new NumberPrimitive(20)
-                )
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -651,15 +680,17 @@ describe("Parser Test", () => {
           ],
           new UnguardedBody(
             new Sequence([
-              new AssignOperation(
-                "Assign",
-                new SymbolPrimitive("X"),
-                new Exist(new SymbolPrimitive("f"), [
-                  new VariablePattern(new SymbolPrimitive("Y")),
-                ])
+              new LogicConstraint(
+                new AssignOperation(
+                  "Assign",
+                  new SymbolPrimitive("X"),
+                  new Exist(new SymbolPrimitive("f"), [
+                    new VariablePattern(new SymbolPrimitive("Y")),
+                  ]),
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -674,13 +705,18 @@ describe("Parser Test", () => {
           ],
           new UnguardedBody(
             new Sequence([
-              new AssignOperation(
-                "Assign",
-                new SymbolPrimitive("X"),
-                new ArithmeticUnaryOperation("Round", new NumberPrimitive(3.5))
+              new LogicConstraint(
+                new AssignOperation(
+                  "Assign",
+                  new SymbolPrimitive("X"),
+                  new ArithmeticUnaryOperation(
+                    "Round",
+                    new NumberPrimitive(3.5),
+                  ),
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -695,19 +731,21 @@ describe("Parser Test", () => {
           ],
           new UnguardedBody(
             new Sequence([
-              new AssignOperation(
-                "Assign",
-                new SymbolPrimitive("X"),
-                new ArithmeticUnaryOperation(
-                  "Absolute",
+              new LogicConstraint(
+                new AssignOperation(
+                  "Assign",
+                  new SymbolPrimitive("X"),
                   new ArithmeticUnaryOperation(
-                    "Negation",
-                    new NumberPrimitive(3.5)
-                  )
-                )
+                    "Absolute",
+                    new ArithmeticUnaryOperation(
+                      "Negation",
+                      new NumberPrimitive(3.5),
+                    ),
+                  ),
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -722,13 +760,18 @@ describe("Parser Test", () => {
           ],
           new UnguardedBody(
             new Sequence([
-              new AssignOperation(
-                "Assign",
-                new SymbolPrimitive("X"),
-                new ArithmeticUnaryOperation("Sqrt", new NumberPrimitive(3.5))
+              new LogicConstraint(
+                new AssignOperation(
+                  "Assign",
+                  new SymbolPrimitive("X"),
+                  new ArithmeticUnaryOperation(
+                    "Sqrt",
+                    new NumberPrimitive(3.5),
+                  ),
+                ),
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -740,21 +783,23 @@ describe("Parser Test", () => {
           [new VariablePattern(new SymbolPrimitive("X"))],
           new UnguardedBody(
             new Sequence([
-              new ComparisonOperation(
-                "GreaterThan",
-                new ArithmeticBinaryOperation(
-                  "Plus",
-                  new SymbolPrimitive("X"),
-                  new NumberPrimitive(50)
+              new LogicConstraint(
+                new ComparisonOperation(
+                  "GreaterThan",
+                  new ArithmeticBinaryOperation(
+                    "Plus",
+                    new SymbolPrimitive("X"),
+                    new NumberPrimitive(50),
+                  ),
+                  new ArithmeticBinaryOperation(
+                    "Multiply",
+                    new SymbolPrimitive("x"),
+                    new NumberPrimitive(2),
+                  ),
                 ),
-                new ArithmeticBinaryOperation(
-                  "Multiply",
-                  new SymbolPrimitive("x"),
-                  new NumberPrimitive(2)
-                )
               ),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -772,8 +817,8 @@ describe("Parser Test", () => {
               new Exist(new SymbolPrimitive("goo"), [
                 new LiteralPattern(new SymbolPrimitive("bar")),
               ]),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -791,8 +836,8 @@ describe("Parser Test", () => {
               new Exist(new SymbolPrimitive("goo"), [
                 new LiteralPattern(new SymbolPrimitive("bar")),
               ]),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -811,8 +856,8 @@ describe("Parser Test", () => {
                 new LiteralPattern(new SymbolPrimitive("bar")),
               ]),
               new Exist(new SymbolPrimitive("baz"), []),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
@@ -832,94 +877,101 @@ describe("Parser Test", () => {
                 new LiteralPattern(new SymbolPrimitive("bar")),
               ]),
               new Exist(new SymbolPrimitive("baz"), []),
-            ])
-          )
+            ]),
+          ),
         ),
       ]),
     ]);
   });
   it("rule/1 with if-then-else construct", () => {
-    assert.deepEqual(
-      parser.parse(
-        `classify_number(X, Classification) :- ( X > 0 -> Classification = positive ; ( X < 0 -> Classification = negative ; Classification = zero )).`
-      ),
-      [
-        new Rule(new SymbolPrimitive("classify_number"), [
-          new Equation(
-            [
-              new VariablePattern(new SymbolPrimitive("X")),
-              new VariablePattern(new SymbolPrimitive("Classification")),
-            ],
-            new UnguardedBody(
-              new Sequence([
-                new If(
+    const input = `classify_number(X, Classification) :- ( X > 0 -> Classification = positive ; ( X < 0 -> Classification = negative ; Classification = zero )).`;
+
+    assert.deepEqual(parser.parse(input), [
+      new Rule(new SymbolPrimitive("classify_number"), [
+        new Equation(
+          [
+            new VariablePattern(new SymbolPrimitive("X")),
+            new VariablePattern(new SymbolPrimitive("Classification")),
+          ],
+          new UnguardedBody(
+            new Sequence([
+              new If(
+                new LogicConstraint(
                   new ComparisonOperation(
                     "GreaterThan",
                     new SymbolPrimitive("X"),
-                    new NumberPrimitive(0)
+                    new NumberPrimitive(0),
                   ),
+                ),
+                new LogicConstraint(
                   new UnifyOperation(
                     "Unify",
                     new SymbolPrimitive("Classification"),
-                    new SymbolPrimitive("positive")
+                    new SymbolPrimitive("positive"),
                   ),
-                  new If(
+                ),
+                new If(
+                  new LogicConstraint(
                     new ComparisonOperation(
                       "LessThan",
                       new SymbolPrimitive("X"),
-                      new NumberPrimitive(0)
+                      new NumberPrimitive(0),
                     ),
+                  ),
+                  new LogicConstraint(
                     new UnifyOperation(
                       "Unify",
                       new SymbolPrimitive("Classification"),
-                      new SymbolPrimitive("negative")
+                      new SymbolPrimitive("negative"),
                     ),
+                  ),
+                  new LogicConstraint(
                     new UnifyOperation(
                       "Unify",
                       new SymbolPrimitive("Classification"),
-                      new SymbolPrimitive("zero")
-                    )
-                  )
+                      new SymbolPrimitive("zero"),
+                    ),
+                  ),
                 ),
-              ])
-            )
+              ),
+            ]),
           ),
-        ]),
-      ]
-    );
+        ),
+      ]),
+    ]);
   });
   it("rule/1 with multiple whitespaces", () => {
     const expectedAST = parser.parse("baz(bar) :- foo(bar), goo(bar), baz.");
 
     assert.deepEqual(
       parser.parse("baz(bar):-foo(bar) , goo(bar), baz."),
-      expectedAST
+      expectedAST,
     );
     assert.deepEqual(
       parser.parse("baz(bar) :- foo(bar) , goo(bar) , baz."),
-      expectedAST
+      expectedAST,
     );
     assert.deepEqual(
       parser.parse("baz(bar) :- foo( bar ) , goo( bar ) , baz."),
-      expectedAST
+      expectedAST,
     );
     assert.deepEqual(
       parser.parse("baz( bar ) :- foo( bar ) , goo( bar ) , baz."),
-      expectedAST
+      expectedAST,
     );
     assert.deepEqual(
       parser.parse("baz( bar ) :- \n foo( bar ) , \n goo( bar ), \n  baz."),
-      expectedAST
+      expectedAST,
     );
     assert.deepEqual(
       parser.parse("baz(bar) :-\n  foo(bar),\n  goo(bar),\n  baz.\n"),
-      expectedAST
+      expectedAST,
     );
   });
   it("can handle single line comments", () => {
     assert.deepEqual(
       parser.parse("%this is a comment\r\nfoo. %this is another comment"),
-      [new Fact(new SymbolPrimitive("foo"), [])]
+      [new Fact(new SymbolPrimitive("foo"), [])],
     );
   });
   it("can handle multi line comments", () => {
@@ -960,7 +1012,7 @@ foo.`;
         new Fact(new SymbolPrimitive("foo"), [
           new ConsPattern(
             new VariablePattern(new SymbolPrimitive("H")),
-            new VariablePattern(new SymbolPrimitive("T"))
+            new VariablePattern(new SymbolPrimitive("T")),
           ),
         ]),
       ]);
@@ -972,8 +1024,8 @@ foo.`;
             new VariablePattern(new SymbolPrimitive("H1")),
             new ConsPattern(
               new VariablePattern(new SymbolPrimitive("H2")),
-              new VariablePattern(new SymbolPrimitive("T"))
-            )
+              new VariablePattern(new SymbolPrimitive("T")),
+            ),
           ),
         ]),
       ]);
@@ -985,17 +1037,19 @@ foo.`;
             [],
             new UnguardedBody(
               new Sequence([
-                new UnifyOperation(
-                  "Unify",
-                  new SymbolPrimitive("X"),
-                  new ListPrimitive([
-                    new NumberPrimitive(1),
-                    new NumberPrimitive(2),
-                    new NumberPrimitive(3),
-                  ])
+                new LogicConstraint(
+                  new UnifyOperation(
+                    "Unify",
+                    new SymbolPrimitive("X"),
+                    new ListPrimitive([
+                      new NumberPrimitive(1),
+                      new NumberPrimitive(2),
+                      new NumberPrimitive(3),
+                    ]),
+                  ),
                 ),
-              ])
-            )
+              ]),
+            ),
           ),
         ]),
       ]);
@@ -1005,22 +1059,23 @@ foo.`;
         new Rule(new SymbolPrimitive("foo"), [
           new Equation(
             [],
-
             new UnguardedBody(
               new Sequence([
-                new UnifyOperation(
-                  "Unify",
-                  new SymbolPrimitive("X"),
-                  new ConsExpression(
-                    new NumberPrimitive(1),
+                new LogicConstraint(
+                  new UnifyOperation(
+                    "Unify",
+                    new SymbolPrimitive("X"),
                     new ConsExpression(
-                      new NumberPrimitive(2),
-                      new SymbolPrimitive("T")
-                    )
-                  )
+                      new NumberPrimitive(1),
+                      new ConsExpression(
+                        new NumberPrimitive(2),
+                        new SymbolPrimitive("T"),
+                      ),
+                    ),
+                  ),
                 ),
-              ])
-            )
+              ]),
+            ),
           ),
         ]),
       ]);

--- a/packages/yukigo-prolog-parser/tests/tests.spec.ts
+++ b/packages/yukigo-prolog-parser/tests/tests.spec.ts
@@ -1,0 +1,82 @@
+import { expect } from "chai";
+import { YukigoPrologParser } from "../src/index.js";
+import {
+  Test,
+  StringPrimitive,
+  Exist,
+  SymbolPrimitive,
+  Fact,
+  LiteralPattern,
+  FunctorPattern
+} from "yukigo-ast";
+
+describe("Prolog Test Parsing", () => {
+  const parser = new YukigoPrologParser("");
+
+  it("should parse a simple test rule", () => {
+    const code = `test('socrates es persona'):- persona(socrates).`;
+    const ast = parser.parse(code);
+    
+    expect(ast).to.have.lengthOf(1);
+    expect(ast[0]).to.be.instanceOf(Test);
+    
+    const test = ast[0] as Test;
+    expect(test.name).to.be.instanceOf(StringPrimitive);
+    expect((test.name as StringPrimitive).value).to.equal("'socrates es persona'");
+    
+    expect(test.body.statements).to.have.lengthOf(1);
+    expect(test.body.statements[0]).to.be.instanceOf(Exist);
+    const body = test.body.statements[0] as Exist;
+    expect((body.identifier as SymbolPrimitive).value).to.equal("persona");
+  });
+
+  it("should parse multiple tests", () => {
+    const code = `
+test('test 1'):- a(b).
+test('test 2'):- c(d).
+    `;
+    const ast = parser.parse(code);
+    expect(ast).to.have.lengthOf(2);
+    expect(ast[0]).to.be.instanceOf(Test);
+    expect(ast[1]).to.be.instanceOf(Test);
+  });
+
+  it("should parse tests mixed with facts", () => {
+    const code = `
+persona(socrates).
+test('es persona'):- persona(socrates).
+    `;
+    const ast = parser.parse(code);
+    expect(ast).to.have.lengthOf(2);
+    expect(ast[0]).to.be.instanceOf(Fact);
+    expect(ast[1]).to.be.instanceOf(Test);
+  });
+
+  it("should parse a test rule with options (test/2)", () => {
+    const code = `test(caba_esta_decidida_por_plis, nondet):- decidida(caba).`;
+    const ast = parser.parse(code);
+    
+    expect(ast).to.have.lengthOf(1);
+    expect(ast[0]).to.be.instanceOf(Test);
+    
+    const test = ast[0] as Test;
+    expect(test.name).to.be.instanceOf(SymbolPrimitive);
+    expect((test.name as SymbolPrimitive).value).to.equal("caba_esta_decidida_por_plis");
+    
+    expect(test.args[0]).to.be.instanceOf(LiteralPattern);
+    const args = test.args[0] as LiteralPattern;
+    expect(args.name).to.be.instanceOf(SymbolPrimitive);
+    expect((args.name as SymbolPrimitive).value).to.equal("nondet");
+  });
+
+  it("should parse a complex test rule with options", () => {
+    const code = "test(caba_esta_decidida_por_plis, nondet):-\n\tdecidida(caba).\n\t\ntest(bsas_no_esta_decidida_porque_hay_mas_de_un_partido_muy_votado, fail):-\n\tdecidida(bsas).\n\t\ntest(corrientes_no_esta_decidida_porque_no_hay_partidos_muy_votados, fail):-\n\tdecidida(corrientes).\n\t\ntest(decidida_es_inversible, set(Provincia = [chaco, rioNegro, caba, jujuy, salta, laPampa])):-\n  decidida(Provincia).\n";
+    const ast = parser.parse(code);
+    
+    expect(ast).to.have.lengthOf(4);
+    expect(ast[0]).to.be.instanceOf(Test);
+    
+    const test = ast[0] as Test;
+    expect(test.args[0]).to.be.instanceOf(LiteralPattern);
+  });
+});

--- a/packages/yukigo-prolog-parser/tsconfig.json
+++ b/packages/yukigo-prolog-parser/tsconfig.json
@@ -5,6 +5,7 @@
     "moduleResolution": "nodenext",
     "lib": ["ES2024"],
     "outDir": "./dist",
+    "rootDir": "src",
     "sourceRoot": "./src",
     "declaration": true,
     "composite": true,


### PR DESCRIPTION
Added `Assert`, `Test`, and `TestGroup` support for Haskell and Prolog implementations.

Also added support for some math predicates in the Prolog's `std.pl`