### PR TITLE
Arreglo mal manejo de entornos que causaban recursion infinita

### DIFF
--- a/packages/yukigo/src/interpreter/components/PatternMatcher.ts
+++ b/packages/yukigo/src/interpreter/components/PatternMatcher.ts
@@ -21,6 +21,7 @@ import {
   TypePattern,
   SimpleType,
   ListType,
+  EnvStack,
 } from "yukigo-ast";
 import { Bindings } from "../index.js";
 import { InterpreterVisitor } from "./Visitor.js";
@@ -61,6 +62,7 @@ export interface InternalConsState {
   readonly head: PrimitiveValue;
   readonly tailExpr: Expression;
   readonly evaluator: ExpressionEvaluator;
+  readonly capturedEnv: EnvStack;
   realizedTail?: PrimitiveValue;
 }
 

--- a/packages/yukigo/src/interpreter/components/RuntimeContext.ts
+++ b/packages/yukigo/src/interpreter/components/RuntimeContext.ts
@@ -87,12 +87,12 @@ export class RuntimeContext {
 
     return false;
   }
-  public popEnv(env: EnvStack) {
-    if (!env.tail)
+  public popEnv() {
+    if (!this.env.tail)
       throw new Error(
         "Runtime Error: Cannot pop the global environment scope.",
       );
-    this.env = env.tail;
+    this.env = this.env.tail;
   }
   public lookup(name: string): PrimitiveValue {
     let current: EnvStack | null = this.env;

--- a/packages/yukigo/src/interpreter/components/RuntimeContext.ts
+++ b/packages/yukigo/src/interpreter/components/RuntimeContext.ts
@@ -4,7 +4,6 @@ import { LazyRuntime } from "./runtimes/LazyRuntime.js";
 import { ObjectRuntime } from "./runtimes/ObjectRuntime.js";
 import { createGlobalEnv } from "../utils.js";
 import { UnboundVariable } from "../errors.js";
-import { inspect } from "util";
 
 export const DefaultConfiguration: Required<InterpreterConfig> = {
   lazyLoading: false,
@@ -109,5 +108,12 @@ export class RuntimeContext {
   }
   public define(name: string, value: PrimitiveValue): void {
     this.env.head.set(name, value);
+  }
+  public clone(env?: EnvStack): EnvStack {
+    const target = env ?? this.env;
+    return {
+      head: new Map(target.head),
+      tail: this.env.tail,
+    };
   }
 }

--- a/packages/yukigo/src/interpreter/components/Visitor.ts
+++ b/packages/yukigo/src/interpreter/components/Visitor.ts
@@ -684,6 +684,7 @@ export class InterpreterVisitor
   }
 
   visitApplication(node: Application): CPSThunk<PrimitiveValue> {
+    const { funcRuntime } = this.context
     if (this.context.config.debug) {
       console.log(`[Interpreter] Visiting Application`);
     }
@@ -695,53 +696,26 @@ export class InterpreterVisitor
             "Cannot apply non-function",
           );
 
-        return this.evaluate(node.parameter, (arg) => {
-          const argThunk = () => arg;
-          const allPendingArgs = func.pendingArgs
-            ? [...func.pendingArgs, argThunk]
-            : [argThunk];
-
-          return this.applyArguments(func, allPendingArgs)(k);
-        });
-      });
-  }
-
-  private applyArguments(
-    func: RuntimeFunction,
-    args: (PrimitiveValue | (() => PrimitiveValue))[],
-  ): CPSThunk<PrimitiveValue> {
-    if (args.length < func.arity) {
-      return valueToCPS({
-        ...func,
-        pendingArgs: args,
-      });
-    }
-
-    const argsToConsume = args.slice(0, func.arity);
-    const remainingArgs = args.slice(func.arity);
-
-    const evaluatedArgs = argsToConsume.map((arg) =>
-      typeof arg === "function" ? arg() : arg,
-    );
-
-    if (func.closure) this.context.pushEnv(func.closure.head);
-    return (cont) => () =>
-      this.context.funcRuntime.apply(func, evaluatedArgs, (result) => {
-        if (remainingArgs.length > 0) {
-          if (isRuntimeFunction(result)) {
-            const nextArgs = result.pendingArgs
-              ? [...result.pendingArgs, ...remainingArgs]
-              : remainingArgs;
-
-            return this.applyArguments(result, nextArgs)(cont);
-          } else {
-            throw new InterpreterError(
-              "Application",
-              `Too many arguments provided. Result was '${result}' (not a function), but had ${remainingArgs.length} args left.`,
-            );
-          }
+        const applyFuncToNode = (func: RuntimeFunction): CPSThunk<PrimitiveValue> => (k) =>
+          this.evaluate(node.parameter, (arg) => {
+            const argThunk = () => arg;
+            const allPendingArgs = func.pendingArgs
+              ? [...func.pendingArgs, argThunk]
+              : [argThunk];
+            return funcRuntime.applyArguments(func, allPendingArgs)(k);
+          });
+        if (func.arity === 0) {
+          return funcRuntime.applyArguments(func, [])(resultOfFunc => {
+            if (!isRuntimeFunction(resultOfFunc))
+              throw new InterpreterError(
+                "Application",
+                `Cannot apply non-function result of arity-0 function`,
+              );
+            return applyFuncToNode(resultOfFunc)(k);
+          });
         }
-        return cont(result);
+
+        return applyFuncToNode(func)(k);
       });
   }
 

--- a/packages/yukigo/src/interpreter/components/runtimes/FunctionRuntime.ts
+++ b/packages/yukigo/src/interpreter/components/runtimes/FunctionRuntime.ts
@@ -4,16 +4,16 @@ import {
   UnguardedBody,
   Sequence,
   Return,
-  EnvStack,
   Function,
   RuntimeFunction,
+  isRuntimeFunction,
 } from "yukigo-ast";
 import { Bindings } from "../../index.js";
 import { PatternMatcher } from "../PatternMatcher.js";
 import { ExpressionEvaluator } from "../../utils.js";
 import { InterpreterError } from "../../errors.js";
 import { EnvBuilderVisitor } from "../EnvBuilder.js";
-import { Continuation, Thunk } from "../../trampoline.js";
+import { Continuation, CPSThunk, Thunk, valueToCPS } from "../../trampoline.js";
 import { RuntimeContext } from "../RuntimeContext.js";
 import { InterpreterVisitor } from "../Visitor.js";
 
@@ -35,6 +35,7 @@ export class FunctionRuntime {
   ): Thunk<PrimitiveValue> {
     const funcName = func.identifier;
     const equations = func.equations;
+    const oldEnv = this.context.env;
 
     if (this.context.config.debug)
       console.log(
@@ -44,6 +45,7 @@ export class FunctionRuntime {
 
     const tryNextEquation = (eqIndex: number): Thunk<PrimitiveValue> => {
       if (eqIndex >= equations.length) {
+        this.context.setEnv(oldEnv);
         throw new NonExhaustivePatterns(funcName);
       }
 
@@ -62,7 +64,6 @@ export class FunctionRuntime {
           );
 
         const localEnv = new Map<string, PrimitiveValue>(bindings);
-        const oldEnv = this.context.env;
         if (func.closure) this.context.setEnv(func.closure);
         this.context.pushEnv(localEnv);
 
@@ -122,6 +123,44 @@ export class FunctionRuntime {
     };
 
     return tryNextEquation(0);
+  }
+
+  public applyArguments(
+    func: RuntimeFunction,
+    args: (PrimitiveValue | (() => PrimitiveValue))[],
+  ): CPSThunk<PrimitiveValue> {
+    if (args.length < func.arity) {
+      return valueToCPS({
+        ...func,
+        pendingArgs: args,
+      });
+    }
+
+    const argsToConsume = args.slice(0, func.arity);
+    const remainingArgs = args.slice(func.arity);
+
+    const evaluatedArgs = argsToConsume.map((arg) =>
+      typeof arg === "function" ? arg() : arg,
+    );
+
+    return (cont) => () =>
+      this.apply(func, evaluatedArgs, (result) => {
+        if (remainingArgs.length > 0) {
+          if (isRuntimeFunction(result)) {
+            const nextArgs = result.pendingArgs
+              ? [...result.pendingArgs, ...remainingArgs]
+              : remainingArgs;
+
+            return this.applyArguments(result, nextArgs)(cont);
+          } else {
+            throw new InterpreterError(
+              "Application",
+              `Too many arguments provided. Result was '${result}' (not a function), but had ${remainingArgs.length} args left.`,
+            );
+          }
+        }
+        return cont(result);
+      });
   }
 
   private preloadDefinitions(

--- a/packages/yukigo/src/interpreter/components/runtimes/LazyRuntime.ts
+++ b/packages/yukigo/src/interpreter/components/runtimes/LazyRuntime.ts
@@ -118,14 +118,15 @@ export class LazyRuntime {
     evaluator: ExpressionEvaluator,
     k: Continuation<PrimitiveValue>,
   ): Thunk<PrimitiveValue> {
-    const capturedEnv = this.context.env;
     const ctx = this.context;
+    const capturedEnv = ctx.clone();
     return evaluator.evaluate(node.head, (head) => {
-      if (this.context.config.lazyLoading) {
+      if (ctx.config.lazyLoading) {
         const consState: InternalConsState = {
           head,
           tailExpr: node.tail,
           evaluator,
+          capturedEnv,
           realizedTail: undefined,
         };
 
@@ -140,13 +141,10 @@ export class LazyRuntime {
 
                 if (current.realizedTail === undefined) {
                   const prevEnv = ctx.env;
-                  ctx.setEnv(capturedEnv);
+                  ctx.setEnv(current.capturedEnv);
                   try {
                     current.realizedTail = trampoline(
-                      current.evaluator.evaluate(
-                        current.tailExpr,
-                        idContinuation,
-                      ),
+                      current.evaluator.evaluate(current.tailExpr, idContinuation),
                     );
                   } finally {
                     ctx.setEnv(prevEnv);


### PR DESCRIPTION
Closes #58 

Cambios
- Agrego metodo `clone` a `RuntimeContext` que permite hacer una copia del entorno actual.
- Muevo `applyArguments` a `FunctionRuntime`
- Elimino el `pushEnv` en `applyArguments` ya que ya estaba siendo pusheado dentro de el metodo `apply`
- Corrijo manejo de funciones de aridad-0 en el `visitApplication`

Mini fix tambien en `popEnv` que no tenia que recibir ningun parametro