### PR TITLE
Fixeo manejo de igualdad profunda para `TesterRunner` y `LazyRuntime`

### DIFF
--- a/packages/yukigo/src/interpreter/components/TestRunner.ts
+++ b/packages/yukigo/src/interpreter/components/TestRunner.ts
@@ -2,6 +2,7 @@ import {
   Assert,
   Equality,
   Failure,
+  isLazyList,
   PrimitiveValue,
   Test,
   TestGroup,
@@ -118,39 +119,70 @@ class AssertionVisitor extends TraverseVisitor {
   }
   private isEqual(a: any, b: any, k: Continuation<boolean>): Thunk<boolean> {
     if (a === b) return k(true);
-    if (a && b && typeof a === "object" && typeof b === "object") {
-      return this.lazyRuntime.realizeList(a, (valA) => {
-        return () =>
-          this.lazyRuntime.realizeList(b, (valB) => {
-            if (Array.isArray(valA) && Array.isArray(valB)) {
-              if (valA.length !== valB.length) return k(false);
-              const checkNext = (index: number): Thunk<boolean> => {
-                if (index >= valA.length) return k(true);
-                return this.isEqual(valA[index], valB[index], (res) => {
-                  if (!res) return k(false);
-                  return () => checkNext(index + 1);
-                });
-              };
-              return checkNext(0);
-            }
 
-            if (Array.isArray(valA) !== Array.isArray(valB)) return k(false);
+    if (this.isListLike(a) || this.isListLike(b))
+      return this.compareAsLists(a, b, k);
 
-            const keys = Object.keys(valA);
-            if (keys.length !== Object.keys(valB).length) return k(false);
-            const checkNextKey = (index: number): Thunk<boolean> => {
-              if (index >= keys.length) return k(true);
-              const key = keys[index];
-              return this.isEqual(valA[key], valB[key], (res) => {
-                if (!res) return k(false);
-                return () => checkNextKey(index + 1);
-              });
-            };
-            return checkNextKey(0);
-          });
-      });
-    }
+    if (this.isPlainObject(a) && this.isPlainObject(b))
+      return this.compareObjects(a, b, k);
+
     return k(false);
+  }
+
+  private isListLike(val: any): boolean {
+    return Array.isArray(val) || isLazyList(val) || typeof val === "string";
+  }
+
+  private isPlainObject(val: any): boolean {
+    return val !== null && typeof val === "object" && !isLazyList(val);
+  }
+
+  private compareAsLists(
+    a: any,
+    b: any,
+    k: Continuation<boolean>,
+  ): Thunk<boolean> {
+    return this.lazyRuntime.realizeList(
+      a,
+      (valA) => () =>
+        this.lazyRuntime.realizeList(b, (valB) => {
+          if (valA.length !== valB.length) return k(false);
+          return this.compareElementsFrom(valA, valB, 0, k);
+        }),
+    );
+  }
+
+  private compareElementsFrom(
+    a: PrimitiveValue[],
+    b: PrimitiveValue[],
+    index: number,
+    k: Continuation<boolean>,
+  ): Thunk<boolean> {
+    if (index >= a.length) return k(true);
+    return this.isEqual(a[index], b[index], (eq) => {
+      if (!eq) return k(false);
+      return () => this.compareElementsFrom(a, b, index + 1, k);
+    });
+  }
+
+  private compareObjects(
+    a: Record<string, any>,
+    b: Record<string, any>,
+    k: Continuation<boolean>,
+  ): Thunk<boolean> {
+    const keys = Object.keys(a);
+    if (keys.length !== Object.keys(b).length) return k(false);
+
+    const checkNextKey = (index: number): Thunk<boolean> => {
+      if (index >= keys.length) return k(true);
+      const key = keys[index];
+      return this.isEqual(a[key], b[key], (eq) => {
+        if (!eq) return k(false);
+        return () => checkNextKey(index + 1);
+      });
+    };
+
+    return checkNextKey(0);
   }
 }
 

--- a/packages/yukigo/src/interpreter/components/TestRunner.ts
+++ b/packages/yukigo/src/interpreter/components/TestRunner.ts
@@ -85,18 +85,17 @@ class AssertionVisitor extends TraverseVisitor {
       this.interpreter.evaluate(node.value, (value) => {
         return () =>
           this.interpreter.evaluate(node.expected, (expected) => {
-            return this.isEqual(value, expected, (passed) => {
+            this.lazyRuntime.deepEqual(value, expected, (passed) => {
               if (this.negated === passed) {
                 throw new FailedAssert(
-                  value,
-                  expected,
+                  value, expected,
                   this.negated
                     ? `Expected ${JSON.stringify(value)} NOT to be equal to ${JSON.stringify(expected)}`
                     : `Expected ${JSON.stringify(expected)}, but got ${JSON.stringify(value)}`,
                 );
               }
               return k(undefined);
-            });
+            })
           });
       });
   }
@@ -116,73 +115,6 @@ class AssertionVisitor extends TraverseVisitor {
         }
         return k(undefined);
       });
-  }
-  private isEqual(a: any, b: any, k: Continuation<boolean>): Thunk<boolean> {
-    if (a === b) return k(true);
-
-    if (this.isListLike(a) || this.isListLike(b))
-      return this.compareAsLists(a, b, k);
-
-    if (this.isPlainObject(a) && this.isPlainObject(b))
-      return this.compareObjects(a, b, k);
-
-    return k(false);
-  }
-
-  private isListLike(val: any): boolean {
-    return Array.isArray(val) || isLazyList(val) || typeof val === "string";
-  }
-
-  private isPlainObject(val: any): boolean {
-    return val !== null && typeof val === "object" && !isLazyList(val);
-  }
-
-  private compareAsLists(
-    a: any,
-    b: any,
-    k: Continuation<boolean>,
-  ): Thunk<boolean> {
-    return this.lazyRuntime.realizeList(
-      a,
-      (valA) => () =>
-        this.lazyRuntime.realizeList(b, (valB) => {
-          if (valA.length !== valB.length) return k(false);
-          return this.compareElementsFrom(valA, valB, 0, k);
-        }),
-    );
-  }
-
-  private compareElementsFrom(
-    a: PrimitiveValue[],
-    b: PrimitiveValue[],
-    index: number,
-    k: Continuation<boolean>,
-  ): Thunk<boolean> {
-    if (index >= a.length) return k(true);
-    return this.isEqual(a[index], b[index], (eq) => {
-      if (!eq) return k(false);
-      return () => this.compareElementsFrom(a, b, index + 1, k);
-    });
-  }
-
-  private compareObjects(
-    a: Record<string, any>,
-    b: Record<string, any>,
-    k: Continuation<boolean>,
-  ): Thunk<boolean> {
-    const keys = Object.keys(a);
-    if (keys.length !== Object.keys(b).length) return k(false);
-
-    const checkNextKey = (index: number): Thunk<boolean> => {
-      if (index >= keys.length) return k(true);
-      const key = keys[index];
-      return this.isEqual(a[key], b[key], (eq) => {
-        if (!eq) return k(false);
-        return () => checkNextKey(index + 1);
-      });
-    };
-
-    return checkNextKey(0);
   }
 }
 

--- a/packages/yukigo/src/interpreter/components/Visitor.ts
+++ b/packages/yukigo/src/interpreter/components/Visitor.ts
@@ -378,6 +378,17 @@ export class InterpreterVisitor
   visitComparisonOperation(
     node: ComparisonOperation,
   ): CPSThunk<PrimitiveValue> {
+    if (node.operator === "Equal" || node.operator === "NotEqual") {
+      return (k) =>
+        this.evaluate(node.left, (left) => () =>
+          this.evaluate(node.right, (right) =>
+            this.context.lazyRuntime.deepEqual(left, right, (eq) =>
+              k(node.operator === "Equal" ? eq : !eq)
+            )
+          )
+        );
+    }
+
     return this.processBinary(
       node,
       ComparisonOperationTable,

--- a/packages/yukigo/src/interpreter/components/runtimes/LazyRuntime.ts
+++ b/packages/yukigo/src/interpreter/components/runtimes/LazyRuntime.ts
@@ -267,35 +267,65 @@ export class LazyRuntime {
   ): Thunk<R> {
     if (a === b) return k(true);
 
-    const compareValues = (valA: any, valB: any): Thunk<R> => {
-      if (typeof valA === "string" && typeof valB === "string")
-        return k(valA === valB);
+    const aIsListLike = this.isListLike(a);
+    const bIsListLike = this.isListLike(b);
+    const eitherIsCollection = this.isCollection(a) || this.isCollection(b);
 
-      if (Array.isArray(valA) && Array.isArray(valB)) {
-        if (valA.length !== valB.length) return k(false);
-        const compareNext = (index: number): Thunk<R> => {
-          if (index >= valA.length) return k(true);
-          return () =>
-            this.deepEqual(valA[index], valB[index], (isEqual) => {
-              if (!isEqual) return k(false);
-              return () => compareNext(index + 1);
-            });
-        };
-        return compareNext(0);
-      }
-
-      return k(valA == valB);
-    };
-
-    if (isLazyList(a) || isLazyList(b)) {
-      return this.realizeList(a, (valA) => {
-        return () =>
-          this.realizeList(b, (valB) => {
-            return () => compareValues(valA, valB);
-          });
-      });
+    if (eitherIsCollection && aIsListLike && bIsListLike) {
+      return this.realizeList(a, (valA) => () =>
+        this.realizeList(b, (valB) => {
+          if (valA.length !== valB.length) return k(false);
+          return this.deepEqualCollection(valA, valB, 0, k);
+        })
+      );
     }
 
-    return compareValues(a, b);
+    if (eitherIsCollection) return k(false); // colección vs número → false
+
+    if (this.isPlainObject(a) && this.isPlainObject(b))
+      return this.deepEqualObject(a, b, k);
+
+    return k(a == b); // primitivos: number, boolean, string==number
+  }
+  private isPlainObject(val: unknown): val is Record<string, any> {
+    return val !== null && typeof val === "object"
+      && !isLazyList(val) && !Array.isArray(val);
+  }
+  private isCollection(val: unknown): val is PrimitiveValue[] | LazyList {
+    return Array.isArray(val) || isLazyList(val);
+  }
+
+  private isListLike(val: unknown): val is string | PrimitiveValue[] | LazyList {
+    return Array.isArray(val) || isLazyList(val) || typeof val === "string";
+  }
+  private deepEqualCollection<R>(
+    a: PrimitiveValue[],
+    b: PrimitiveValue[],
+    index: number,
+    k: Continuation<boolean, R>,
+  ): Thunk<R> {
+    if (index >= a.length) return k(true);
+    return this.deepEqual(a[index], b[index], (eq) => {
+      if (!eq) return k(false);
+      return () => this.deepEqualCollection(a, b, index + 1, k);
+    });
+  }
+
+  private deepEqualObject<R>(
+    a: Record<string, any>,
+    b: Record<string, any>,
+    k: Continuation<boolean, R>,
+  ): Thunk<R> {
+    const keys = Object.keys(a);
+    if (keys.length !== Object.keys(b).length) return k(false);
+    const checkNext = (index: number): Thunk<R> => {
+      if (index >= keys.length) return k(true);
+      const key = keys[index];
+      return this.deepEqual(a[key], b[key], (eq) => {
+        if (!eq) return k(false);
+        return () => checkNext(index + 1);
+      });
+    };
+    return checkNext(0);
   }
 }


### PR DESCRIPTION
- Delego la logica de comparacion al `LazyRuntime` que puede resolver las estructuras lazily
- Agrego una condicion a `visitComparisonOperation` para que evalue las operaciones `Equal` y `NotEqual` fuera del `processBinary` y aprovechar la logica de `LazyRuntime.deepEqual`
- Semi refactor para abstraer `deepEqual` en varios pasos especificos 