### PR TITLE
Yukigo v0.2.0

### DIFF
--- a/apps/yukigo-docs/docs/components/CodePlayground.vue
+++ b/apps/yukigo-docs/docs/components/CodePlayground.vue
@@ -32,7 +32,7 @@
     <!-- Editor and Terminal -->
     <div class="flex flex-col lg:flex-row w-full gap-4 lg:gap-8">
       <div class="w-full lg:w-1/2 h-80 sm:h-96 lg:h-80">
-        <Editor v-model="code" />
+        <Editor v-model="code" :selectedLanguage="selectedLanguage" />
       </div>
 
       <div class="w-full lg:w-1/2 h-80 sm:h-96 lg:h-80">

--- a/apps/yukigo-docs/docs/components/Editor.vue
+++ b/apps/yukigo-docs/docs/components/Editor.vue
@@ -25,12 +25,14 @@
 import { ref, computed, watch, nextTick, onMounted, defineProps } from 'vue'
 import Prism from 'prismjs'
 import 'prismjs/components/prism-haskell'
+import 'prismjs/components/prism-prolog'
 import 'prismjs/themes/prism-okaidia.css'
 
 
 const props = defineProps({
   modelValue: { type: String, default: '' },
-  readonly: { type: Boolean, default: false }
+  readonly: { type: Boolean, default: false },
+  selectedLanguage: {type: String, default: 'haskell'}
 })
 const emit = defineEmits(['update:modelValue'])
 const internalValue = ref(props.modelValue)
@@ -44,7 +46,7 @@ const lineCount = computed(() => Array.from({ length: Math.max(internalValue.val
 
 const highlightedCode = computed(() => {
   try {
-    return Prism.highlight(internalValue.value, Prism.languages.haskell, 'haskell')
+    return Prism.highlight(internalValue.value, Prism.languages[props.selectedLanguage??'haskell'], props.selectedLanguage??'haskell')
   } catch {
     return internalValue.value
   }

--- a/apps/yukigo-docs/docs/components/Hero.vue
+++ b/apps/yukigo-docs/docs/components/Hero.vue
@@ -18,6 +18,7 @@ const t = {
 }
 
 const tr = computed(() => t[lang.value] ?? t['en'])
+console.log(lang)
 </script>
 <template>
   <div class="flex gap-4 sm:gap-6 lg:gap-8 flex-col w-full mt-10 sm:mt-16 lg:mt-20 justify-center items-center text-center">
@@ -28,7 +29,7 @@ const tr = computed(() => t[lang.value] ?? t['en'])
       {{ tr.tagline }}
     </span>
     <div class="flex flex-col sm:flex-row gap-3 sm:gap-4 items-center justify-center mt-4">
-      <a class="bg-primary px-4 py-2 rounded-2xl w-full sm:w-auto text-center" href="/getting-started/">
+      <a class="bg-primary px-4 py-2 rounded-2xl w-full sm:w-auto text-center" :href="'/yukigo/' + lang + '/getting-started/'">
         {{ tr.getStarted }}
       </a>
       <a class="alt text-center w-full sm:w-auto" href="https://github.com/miyukiproject/yukigo" target="_blank">

--- a/apps/yukigo-docs/docs/components/Hero.vue
+++ b/apps/yukigo-docs/docs/components/Hero.vue
@@ -18,7 +18,6 @@ const t = {
 }
 
 const tr = computed(() => t[lang.value] ?? t['en'])
-console.log(lang)
 </script>
 <template>
   <div class="flex gap-4 sm:gap-6 lg:gap-8 flex-col w-full mt-10 sm:mt-16 lg:mt-20 justify-center items-center text-center">

--- a/package-lock.json
+++ b/package-lock.json
@@ -10633,7 +10633,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10650,7 +10649,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10667,7 +10665,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10684,7 +10681,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10701,7 +10697,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10718,7 +10713,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10735,7 +10729,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10752,7 +10745,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10769,7 +10761,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10786,7 +10777,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10803,7 +10793,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10820,7 +10809,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10837,7 +10825,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10854,7 +10841,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10871,7 +10857,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10888,7 +10873,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10905,7 +10889,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10922,7 +10905,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10939,7 +10921,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10956,7 +10937,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10973,7 +10953,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10990,7 +10969,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11007,7 +10985,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11024,7 +11001,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11041,7 +11017,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -11058,7 +11033,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12944,6 +12918,11 @@
       "version": "0.1.0",
       "license": "ISC",
       "devDependencies": {
+        "@types/chai": "^5.2.2",
+        "@types/mocha": "^10.0.10",
+        "@types/node": "^24.2.0",
+        "chai": "^6.2.0",
+        "mocha": "^11.7.1",
         "tsup": "^8.5.0",
         "typescript": "^5.9.2"
       }

--- a/packages/yukigo-ast/.mocharc.json
+++ b/packages/yukigo-ast/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "extension": ["ts"],
+  "spec": "tests/**/*.spec.ts"
+}

--- a/packages/yukigo-ast/package.json
+++ b/packages/yukigo-ast/package.json
@@ -13,13 +13,19 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "test": "mocha --import=tsx"
   },
   "keywords": [],
   "author": "noiseArch",
   "license": "ISC",
   "devDependencies": {
     "tsup": "^8.5.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "@types/chai": "^5.2.2",
+    "@types/mocha": "^10.0.10",
+    "@types/node": "^24.2.0",
+    "chai": "^6.2.0",
+    "mocha": "^11.7.1"
   }
 }

--- a/packages/yukigo-ast/src/globals/generics.ts
+++ b/packages/yukigo-ast/src/globals/generics.ts
@@ -32,6 +32,10 @@ export abstract class ASTNode {
     return this.metadata.has(key);
   }
 
+  public is<T extends ASTNode>( nodeType : new (...args: any[]) => T ): this is T {
+    return this instanceof nodeType;
+  }
+
   /** @hidden */
   abstract accept<R>(visitor: Visitor<R>): R;
   /** @hidden */

--- a/packages/yukigo-ast/tests/ast.spec.ts
+++ b/packages/yukigo-ast/tests/ast.spec.ts
@@ -1,0 +1,17 @@
+import { expect } from "chai";
+import { ASTNode, NumberPrimitive, StringPrimitive } from "../dist";
+import { it } from "mocha";
+
+describe("AST", () => {
+
+  it("funcion is da true si concide el constructor", () => {
+    const nodoPrueba = new NumberPrimitive(1);
+    expect(nodoPrueba.is(NumberPrimitive)).to.be.true;
+  });
+
+  it("funcion is da false si no conincide el constructor", () => {
+    const nodoPrueba = new NumberPrimitive(1);
+    expect(nodoPrueba.is(StringPrimitive)).to.be.false;
+  });
+
+});

--- a/packages/yukigo/src/analyzer/index.ts
+++ b/packages/yukigo/src/analyzer/index.ts
@@ -22,7 +22,7 @@ export type AnalysisResult = {
 export type InspectionRule = {
   inspection: string;
   binding?: string;
-  args: string[];
+  args?: string[];
   expected: boolean;
 };
 
@@ -154,7 +154,8 @@ export class Analyzer {
       // Execution Loop
       const isGlobalVisitor = !rule.binding || rule.binding === "*";
       const normalizedBinding = isGlobalVisitor ? undefined : rule.binding;
-      const visitor = new InspectionClass(...rule.args, normalizedBinding);
+      const args = rule.args ?? []
+      const visitor = new InspectionClass(...args, normalizedBinding);
 
       for (const { node, binding } of targets) {
         try {

--- a/packages/yukigo/src/interpreter/components/PatternMatcher.ts
+++ b/packages/yukigo/src/interpreter/components/PatternMatcher.ts
@@ -21,6 +21,7 @@ import {
   TypePattern,
   SimpleType,
   ListType,
+  EnvStack,
 } from "yukigo-ast";
 import { Bindings } from "../index.js";
 import { InterpreterVisitor } from "./Visitor.js";
@@ -61,6 +62,7 @@ export interface InternalConsState {
   readonly head: PrimitiveValue;
   readonly tailExpr: Expression;
   readonly evaluator: ExpressionEvaluator;
+  readonly capturedEnv: EnvStack;
   realizedTail?: PrimitiveValue;
 }
 

--- a/packages/yukigo/src/interpreter/components/RuntimeContext.ts
+++ b/packages/yukigo/src/interpreter/components/RuntimeContext.ts
@@ -87,12 +87,12 @@ export class RuntimeContext {
 
     return false;
   }
-  public popEnv(env: EnvStack) {
-    if (!env.tail)
+  public popEnv() {
+    if (!this.env.tail)
       throw new Error(
         "Runtime Error: Cannot pop the global environment scope.",
       );
-    this.env = env.tail;
+    this.env = this.env.tail;
   }
   public lookup(name: string): PrimitiveValue {
     let current: EnvStack | null = this.env;

--- a/packages/yukigo/src/interpreter/components/RuntimeContext.ts
+++ b/packages/yukigo/src/interpreter/components/RuntimeContext.ts
@@ -4,7 +4,6 @@ import { LazyRuntime } from "./runtimes/LazyRuntime.js";
 import { ObjectRuntime } from "./runtimes/ObjectRuntime.js";
 import { createGlobalEnv } from "../utils.js";
 import { UnboundVariable } from "../errors.js";
-import { inspect } from "util";
 
 export const DefaultConfiguration: Required<InterpreterConfig> = {
   lazyLoading: false,
@@ -109,5 +108,12 @@ export class RuntimeContext {
   }
   public define(name: string, value: PrimitiveValue): void {
     this.env.head.set(name, value);
+  }
+  public clone(env?: EnvStack): EnvStack {
+    const target = env ?? this.env;
+    return {
+      head: new Map(target.head),
+      tail: this.env.tail,
+    };
   }
 }

--- a/packages/yukigo/src/interpreter/components/TestRunner.ts
+++ b/packages/yukigo/src/interpreter/components/TestRunner.ts
@@ -2,6 +2,7 @@ import {
   Assert,
   Equality,
   Failure,
+  isLazyList,
   PrimitiveValue,
   Test,
   TestGroup,
@@ -118,39 +119,70 @@ class AssertionVisitor extends TraverseVisitor {
   }
   private isEqual(a: any, b: any, k: Continuation<boolean>): Thunk<boolean> {
     if (a === b) return k(true);
-    if (a && b && typeof a === "object" && typeof b === "object") {
-      return this.lazyRuntime.realizeList(a, (valA) => {
-        return () =>
-          this.lazyRuntime.realizeList(b, (valB) => {
-            if (Array.isArray(valA) && Array.isArray(valB)) {
-              if (valA.length !== valB.length) return k(false);
-              const checkNext = (index: number): Thunk<boolean> => {
-                if (index >= valA.length) return k(true);
-                return this.isEqual(valA[index], valB[index], (res) => {
-                  if (!res) return k(false);
-                  return () => checkNext(index + 1);
-                });
-              };
-              return checkNext(0);
-            }
 
-            if (Array.isArray(valA) !== Array.isArray(valB)) return k(false);
+    if (this.isListLike(a) || this.isListLike(b))
+      return this.compareAsLists(a, b, k);
 
-            const keys = Object.keys(valA);
-            if (keys.length !== Object.keys(valB).length) return k(false);
-            const checkNextKey = (index: number): Thunk<boolean> => {
-              if (index >= keys.length) return k(true);
-              const key = keys[index];
-              return this.isEqual(valA[key], valB[key], (res) => {
-                if (!res) return k(false);
-                return () => checkNextKey(index + 1);
-              });
-            };
-            return checkNextKey(0);
-          });
-      });
-    }
+    if (this.isPlainObject(a) && this.isPlainObject(b))
+      return this.compareObjects(a, b, k);
+
     return k(false);
+  }
+
+  private isListLike(val: any): boolean {
+    return Array.isArray(val) || isLazyList(val) || typeof val === "string";
+  }
+
+  private isPlainObject(val: any): boolean {
+    return val !== null && typeof val === "object" && !isLazyList(val);
+  }
+
+  private compareAsLists(
+    a: any,
+    b: any,
+    k: Continuation<boolean>,
+  ): Thunk<boolean> {
+    return this.lazyRuntime.realizeList(
+      a,
+      (valA) => () =>
+        this.lazyRuntime.realizeList(b, (valB) => {
+          if (valA.length !== valB.length) return k(false);
+          return this.compareElementsFrom(valA, valB, 0, k);
+        }),
+    );
+  }
+
+  private compareElementsFrom(
+    a: PrimitiveValue[],
+    b: PrimitiveValue[],
+    index: number,
+    k: Continuation<boolean>,
+  ): Thunk<boolean> {
+    if (index >= a.length) return k(true);
+    return this.isEqual(a[index], b[index], (eq) => {
+      if (!eq) return k(false);
+      return () => this.compareElementsFrom(a, b, index + 1, k);
+    });
+  }
+
+  private compareObjects(
+    a: Record<string, any>,
+    b: Record<string, any>,
+    k: Continuation<boolean>,
+  ): Thunk<boolean> {
+    const keys = Object.keys(a);
+    if (keys.length !== Object.keys(b).length) return k(false);
+
+    const checkNextKey = (index: number): Thunk<boolean> => {
+      if (index >= keys.length) return k(true);
+      const key = keys[index];
+      return this.isEqual(a[key], b[key], (eq) => {
+        if (!eq) return k(false);
+        return () => checkNextKey(index + 1);
+      });
+    };
+
+    return checkNextKey(0);
   }
 }
 

--- a/packages/yukigo/src/interpreter/components/TestRunner.ts
+++ b/packages/yukigo/src/interpreter/components/TestRunner.ts
@@ -85,18 +85,17 @@ class AssertionVisitor extends TraverseVisitor {
       this.interpreter.evaluate(node.value, (value) => {
         return () =>
           this.interpreter.evaluate(node.expected, (expected) => {
-            return this.isEqual(value, expected, (passed) => {
+            this.lazyRuntime.deepEqual(value, expected, (passed) => {
               if (this.negated === passed) {
                 throw new FailedAssert(
-                  value,
-                  expected,
+                  value, expected,
                   this.negated
                     ? `Expected ${JSON.stringify(value)} NOT to be equal to ${JSON.stringify(expected)}`
                     : `Expected ${JSON.stringify(expected)}, but got ${JSON.stringify(value)}`,
                 );
               }
               return k(undefined);
-            });
+            })
           });
       });
   }
@@ -116,73 +115,6 @@ class AssertionVisitor extends TraverseVisitor {
         }
         return k(undefined);
       });
-  }
-  private isEqual(a: any, b: any, k: Continuation<boolean>): Thunk<boolean> {
-    if (a === b) return k(true);
-
-    if (this.isListLike(a) || this.isListLike(b))
-      return this.compareAsLists(a, b, k);
-
-    if (this.isPlainObject(a) && this.isPlainObject(b))
-      return this.compareObjects(a, b, k);
-
-    return k(false);
-  }
-
-  private isListLike(val: any): boolean {
-    return Array.isArray(val) || isLazyList(val) || typeof val === "string";
-  }
-
-  private isPlainObject(val: any): boolean {
-    return val !== null && typeof val === "object" && !isLazyList(val);
-  }
-
-  private compareAsLists(
-    a: any,
-    b: any,
-    k: Continuation<boolean>,
-  ): Thunk<boolean> {
-    return this.lazyRuntime.realizeList(
-      a,
-      (valA) => () =>
-        this.lazyRuntime.realizeList(b, (valB) => {
-          if (valA.length !== valB.length) return k(false);
-          return this.compareElementsFrom(valA, valB, 0, k);
-        }),
-    );
-  }
-
-  private compareElementsFrom(
-    a: PrimitiveValue[],
-    b: PrimitiveValue[],
-    index: number,
-    k: Continuation<boolean>,
-  ): Thunk<boolean> {
-    if (index >= a.length) return k(true);
-    return this.isEqual(a[index], b[index], (eq) => {
-      if (!eq) return k(false);
-      return () => this.compareElementsFrom(a, b, index + 1, k);
-    });
-  }
-
-  private compareObjects(
-    a: Record<string, any>,
-    b: Record<string, any>,
-    k: Continuation<boolean>,
-  ): Thunk<boolean> {
-    const keys = Object.keys(a);
-    if (keys.length !== Object.keys(b).length) return k(false);
-
-    const checkNextKey = (index: number): Thunk<boolean> => {
-      if (index >= keys.length) return k(true);
-      const key = keys[index];
-      return this.isEqual(a[key], b[key], (eq) => {
-        if (!eq) return k(false);
-        return () => checkNextKey(index + 1);
-      });
-    };
-
-    return checkNextKey(0);
   }
 }
 

--- a/packages/yukigo/src/interpreter/components/Visitor.ts
+++ b/packages/yukigo/src/interpreter/components/Visitor.ts
@@ -684,6 +684,7 @@ export class InterpreterVisitor
   }
 
   visitApplication(node: Application): CPSThunk<PrimitiveValue> {
+    const { funcRuntime } = this.context
     if (this.context.config.debug) {
       console.log(`[Interpreter] Visiting Application`);
     }
@@ -695,53 +696,26 @@ export class InterpreterVisitor
             "Cannot apply non-function",
           );
 
-        return this.evaluate(node.parameter, (arg) => {
-          const argThunk = () => arg;
-          const allPendingArgs = func.pendingArgs
-            ? [...func.pendingArgs, argThunk]
-            : [argThunk];
-
-          return this.applyArguments(func, allPendingArgs)(k);
-        });
-      });
-  }
-
-  private applyArguments(
-    func: RuntimeFunction,
-    args: (PrimitiveValue | (() => PrimitiveValue))[],
-  ): CPSThunk<PrimitiveValue> {
-    if (args.length < func.arity) {
-      return valueToCPS({
-        ...func,
-        pendingArgs: args,
-      });
-    }
-
-    const argsToConsume = args.slice(0, func.arity);
-    const remainingArgs = args.slice(func.arity);
-
-    const evaluatedArgs = argsToConsume.map((arg) =>
-      typeof arg === "function" ? arg() : arg,
-    );
-
-    if (func.closure) this.context.pushEnv(func.closure.head);
-    return (cont) => () =>
-      this.context.funcRuntime.apply(func, evaluatedArgs, (result) => {
-        if (remainingArgs.length > 0) {
-          if (isRuntimeFunction(result)) {
-            const nextArgs = result.pendingArgs
-              ? [...result.pendingArgs, ...remainingArgs]
-              : remainingArgs;
-
-            return this.applyArguments(result, nextArgs)(cont);
-          } else {
-            throw new InterpreterError(
-              "Application",
-              `Too many arguments provided. Result was '${result}' (not a function), but had ${remainingArgs.length} args left.`,
-            );
-          }
+        const applyFuncToNode = (func: RuntimeFunction): CPSThunk<PrimitiveValue> => (k) =>
+          this.evaluate(node.parameter, (arg) => {
+            const argThunk = () => arg;
+            const allPendingArgs = func.pendingArgs
+              ? [...func.pendingArgs, argThunk]
+              : [argThunk];
+            return funcRuntime.applyArguments(func, allPendingArgs)(k);
+          });
+        if (func.arity === 0) {
+          return funcRuntime.applyArguments(func, [])(resultOfFunc => {
+            if (!isRuntimeFunction(resultOfFunc))
+              throw new InterpreterError(
+                "Application",
+                `Cannot apply non-function result of arity-0 function`,
+              );
+            return applyFuncToNode(resultOfFunc)(k);
+          });
         }
-        return cont(result);
+
+        return applyFuncToNode(func)(k);
       });
   }
 

--- a/packages/yukigo/src/interpreter/components/Visitor.ts
+++ b/packages/yukigo/src/interpreter/components/Visitor.ts
@@ -985,7 +985,9 @@ export class InterpreterVisitor
       return process(0);
     };
   }
-
+  visitTypeCast(node: TypeCast): CPSThunk<PrimitiveValue> {
+    return node.expression.accept(this);
+  }
   visitGenerator(node: YuGenerator): CPSThunk<PrimitiveValue> {
     return (k) => this.evaluate(node.expression, k);
   }

--- a/packages/yukigo/src/interpreter/components/Visitor.ts
+++ b/packages/yukigo/src/interpreter/components/Visitor.ts
@@ -378,6 +378,17 @@ export class InterpreterVisitor
   visitComparisonOperation(
     node: ComparisonOperation,
   ): CPSThunk<PrimitiveValue> {
+    if (node.operator === "Equal" || node.operator === "NotEqual") {
+      return (k) =>
+        this.evaluate(node.left, (left) => () =>
+          this.evaluate(node.right, (right) =>
+            this.context.lazyRuntime.deepEqual(left, right, (eq) =>
+              k(node.operator === "Equal" ? eq : !eq)
+            )
+          )
+        );
+    }
+
     return this.processBinary(
       node,
       ComparisonOperationTable,

--- a/packages/yukigo/src/interpreter/components/runtimes/FunctionRuntime.ts
+++ b/packages/yukigo/src/interpreter/components/runtimes/FunctionRuntime.ts
@@ -4,16 +4,16 @@ import {
   UnguardedBody,
   Sequence,
   Return,
-  EnvStack,
   Function,
   RuntimeFunction,
+  isRuntimeFunction,
 } from "yukigo-ast";
 import { Bindings } from "../../index.js";
 import { PatternMatcher } from "../PatternMatcher.js";
 import { ExpressionEvaluator } from "../../utils.js";
 import { InterpreterError } from "../../errors.js";
 import { EnvBuilderVisitor } from "../EnvBuilder.js";
-import { Continuation, Thunk } from "../../trampoline.js";
+import { Continuation, CPSThunk, Thunk, valueToCPS } from "../../trampoline.js";
 import { RuntimeContext } from "../RuntimeContext.js";
 import { InterpreterVisitor } from "../Visitor.js";
 
@@ -35,6 +35,7 @@ export class FunctionRuntime {
   ): Thunk<PrimitiveValue> {
     const funcName = func.identifier;
     const equations = func.equations;
+    const oldEnv = this.context.env;
 
     if (this.context.config.debug)
       console.log(
@@ -44,6 +45,7 @@ export class FunctionRuntime {
 
     const tryNextEquation = (eqIndex: number): Thunk<PrimitiveValue> => {
       if (eqIndex >= equations.length) {
+        this.context.setEnv(oldEnv);
         throw new NonExhaustivePatterns(funcName);
       }
 
@@ -62,7 +64,6 @@ export class FunctionRuntime {
           );
 
         const localEnv = new Map<string, PrimitiveValue>(bindings);
-        const oldEnv = this.context.env;
         if (func.closure) this.context.setEnv(func.closure);
         this.context.pushEnv(localEnv);
 
@@ -122,6 +123,44 @@ export class FunctionRuntime {
     };
 
     return tryNextEquation(0);
+  }
+
+  public applyArguments(
+    func: RuntimeFunction,
+    args: (PrimitiveValue | (() => PrimitiveValue))[],
+  ): CPSThunk<PrimitiveValue> {
+    if (args.length < func.arity) {
+      return valueToCPS({
+        ...func,
+        pendingArgs: args,
+      });
+    }
+
+    const argsToConsume = args.slice(0, func.arity);
+    const remainingArgs = args.slice(func.arity);
+
+    const evaluatedArgs = argsToConsume.map((arg) =>
+      typeof arg === "function" ? arg() : arg,
+    );
+
+    return (cont) => () =>
+      this.apply(func, evaluatedArgs, (result) => {
+        if (remainingArgs.length > 0) {
+          if (isRuntimeFunction(result)) {
+            const nextArgs = result.pendingArgs
+              ? [...result.pendingArgs, ...remainingArgs]
+              : remainingArgs;
+
+            return this.applyArguments(result, nextArgs)(cont);
+          } else {
+            throw new InterpreterError(
+              "Application",
+              `Too many arguments provided. Result was '${result}' (not a function), but had ${remainingArgs.length} args left.`,
+            );
+          }
+        }
+        return cont(result);
+      });
   }
 
   private preloadDefinitions(

--- a/packages/yukigo/src/interpreter/components/runtimes/LazyRuntime.ts
+++ b/packages/yukigo/src/interpreter/components/runtimes/LazyRuntime.ts
@@ -267,35 +267,65 @@ export class LazyRuntime {
   ): Thunk<R> {
     if (a === b) return k(true);
 
-    const compareValues = (valA: any, valB: any): Thunk<R> => {
-      if (typeof valA === "string" && typeof valB === "string")
-        return k(valA === valB);
+    const aIsListLike = this.isListLike(a);
+    const bIsListLike = this.isListLike(b);
+    const eitherIsCollection = this.isCollection(a) || this.isCollection(b);
 
-      if (Array.isArray(valA) && Array.isArray(valB)) {
-        if (valA.length !== valB.length) return k(false);
-        const compareNext = (index: number): Thunk<R> => {
-          if (index >= valA.length) return k(true);
-          return () =>
-            this.deepEqual(valA[index], valB[index], (isEqual) => {
-              if (!isEqual) return k(false);
-              return () => compareNext(index + 1);
-            });
-        };
-        return compareNext(0);
-      }
-
-      return k(valA == valB);
-    };
-
-    if (isLazyList(a) || isLazyList(b)) {
-      return this.realizeList(a, (valA) => {
-        return () =>
-          this.realizeList(b, (valB) => {
-            return () => compareValues(valA, valB);
-          });
-      });
+    if (eitherIsCollection && aIsListLike && bIsListLike) {
+      return this.realizeList(a, (valA) => () =>
+        this.realizeList(b, (valB) => {
+          if (valA.length !== valB.length) return k(false);
+          return this.deepEqualCollection(valA, valB, 0, k);
+        })
+      );
     }
 
-    return compareValues(a, b);
+    if (eitherIsCollection) return k(false); // colección vs número → false
+
+    if (this.isPlainObject(a) && this.isPlainObject(b))
+      return this.deepEqualObject(a, b, k);
+
+    return k(a == b); // primitivos: number, boolean, string==number
+  }
+  private isPlainObject(val: unknown): val is Record<string, any> {
+    return val !== null && typeof val === "object"
+      && !isLazyList(val) && !Array.isArray(val);
+  }
+  private isCollection(val: unknown): val is PrimitiveValue[] | LazyList {
+    return Array.isArray(val) || isLazyList(val);
+  }
+
+  private isListLike(val: unknown): val is string | PrimitiveValue[] | LazyList {
+    return Array.isArray(val) || isLazyList(val) || typeof val === "string";
+  }
+  private deepEqualCollection<R>(
+    a: PrimitiveValue[],
+    b: PrimitiveValue[],
+    index: number,
+    k: Continuation<boolean, R>,
+  ): Thunk<R> {
+    if (index >= a.length) return k(true);
+    return this.deepEqual(a[index], b[index], (eq) => {
+      if (!eq) return k(false);
+      return () => this.deepEqualCollection(a, b, index + 1, k);
+    });
+  }
+
+  private deepEqualObject<R>(
+    a: Record<string, any>,
+    b: Record<string, any>,
+    k: Continuation<boolean, R>,
+  ): Thunk<R> {
+    const keys = Object.keys(a);
+    if (keys.length !== Object.keys(b).length) return k(false);
+    const checkNext = (index: number): Thunk<R> => {
+      if (index >= keys.length) return k(true);
+      const key = keys[index];
+      return this.deepEqual(a[key], b[key], (eq) => {
+        if (!eq) return k(false);
+        return () => checkNext(index + 1);
+      });
+    };
+    return checkNext(0);
   }
 }

--- a/packages/yukigo/src/interpreter/components/runtimes/LazyRuntime.ts
+++ b/packages/yukigo/src/interpreter/components/runtimes/LazyRuntime.ts
@@ -118,14 +118,15 @@ export class LazyRuntime {
     evaluator: ExpressionEvaluator,
     k: Continuation<PrimitiveValue>,
   ): Thunk<PrimitiveValue> {
-    const capturedEnv = this.context.env;
     const ctx = this.context;
+    const capturedEnv = ctx.clone();
     return evaluator.evaluate(node.head, (head) => {
-      if (this.context.config.lazyLoading) {
+      if (ctx.config.lazyLoading) {
         const consState: InternalConsState = {
           head,
           tailExpr: node.tail,
           evaluator,
+          capturedEnv,
           realizedTail: undefined,
         };
 
@@ -140,13 +141,10 @@ export class LazyRuntime {
 
                 if (current.realizedTail === undefined) {
                   const prevEnv = ctx.env;
-                  ctx.setEnv(capturedEnv);
+                  ctx.setEnv(current.capturedEnv);
                   try {
                     current.realizedTail = trampoline(
-                      current.evaluator.evaluate(
-                        current.tailExpr,
-                        idContinuation,
-                      ),
+                      current.evaluator.evaluate(current.tailExpr, idContinuation),
                     );
                   } finally {
                     ctx.setEnv(prevEnv);

--- a/packages/yukigo/src/interpreter/components/runtimes/LazyRuntime.ts
+++ b/packages/yukigo/src/interpreter/components/runtimes/LazyRuntime.ts
@@ -236,29 +236,34 @@ export class LazyRuntime {
     evaluator: ExpressionEvaluator,
     k: Continuation<PrimitiveValue>,
   ): Thunk<PrimitiveValue> {
-    const capturedEnv = this.context.env;
     const ctx = this.context;
-    return k(
-      createMemoizedStream(function* () {
-        const prevEnv = ctx.env;
-        ctx.setEnv(capturedEnv);
-        try {
-          const left = trampoline(evaluator.evaluate(node.left, idContinuation));
+
+    return evaluator.evaluate(node.left, (left) => {
+      const capturedEnv = ctx.clone();
+      return k(
+        createMemoizedStream(function* () {
           if (Array.isArray(left)) yield* left;
           else if (typeof left === "string") yield* left.split("");
           else if (isLazyList(left)) yield* left.generator();
+          else throw new Error("Invalid left operand for lazy Concat");
 
-          const right = trampoline(
-            evaluator.evaluate(node.right, idContinuation),
-          );
+          // right evaluates lazily on demand
+          const prevEnv = ctx.env;
+          ctx.setEnv(capturedEnv);
+          let right: PrimitiveValue;
+          try {
+            right = trampoline(evaluator.evaluate(node.right, idContinuation));
+          } finally {
+            ctx.setEnv(prevEnv);
+          }
+
           if (Array.isArray(right)) yield* right;
           else if (typeof right === "string") yield* right.split("");
           else if (isLazyList(right)) yield* right.generator();
-        } finally {
-          ctx.setEnv(prevEnv);
-        }
-      }),
-    );
+          else throw new Error("Invalid right operand for lazy Concat");
+        }),
+      );
+    });
   }
   public deepEqual<R = boolean>(
     a: PrimitiveValue,

--- a/packages/yukigo/tests/analyzer/generic.spec.ts
+++ b/packages/yukigo/tests/analyzer/generic.spec.ts
@@ -5,6 +5,7 @@ import {
   ParameterizedType,
   SymbolPrimitive,
   SimpleType,
+  Function,
 } from "yukigo-ast";
 
 describe("Generic Inspections", () => {
@@ -23,6 +24,19 @@ describe("Generic Inspections", () => {
     return new TypeSignature(identifier, body);
   };
 
+  it("should allow expectations without args", () => {
+    const ast = [new Function(new SymbolPrimitive("func"), [])];
+    const rules: InspectionRule[] = [
+      {
+        binding: "func",
+        inspection: "HasBinding",
+        expected: true
+      },
+    ];
+    const analyzer = new Analyzer();
+    const results = analyzer.analyze(ast, rules);
+    expect(results[0].passed).to.be.true;
+  });
   describe("TypesParameterAs", () => {
     it("should find a match when parameter type matches at correct index", () => {
       const ast = [createTypeSignature("f", ["Int", "String"], "Bool")];

--- a/packages/yukigo/tests/interpreter/interpreter.spec.ts
+++ b/packages/yukigo/tests/interpreter/interpreter.spec.ts
@@ -22,9 +22,11 @@ import {
   RangeExpression,
   Return,
   Sequence,
+  SimpleType,
   StringOperation,
   StringPrimitive,
   SymbolPrimitive,
+  TypeCast,
   UnguardedBody,
   Variable,
   VariablePattern,
@@ -890,6 +892,14 @@ describe("Interpreter Spec", () => {
       const app = new Application(fog, new NumberPrimitive(2));
       const res = interpreter.evaluate(app)
       assert.equal(res, 16);
+    });
+  });
+  describe("Evaluates TypeCast", () => {
+    it("Type casting of number 2 to string should be '2'", () => {
+      const res = interpreter.evaluate(
+        new TypeCast(new NumberPrimitive(2), new SimpleType("String", [])),
+      );
+      assert.equal(res, "2");
     });
   });
   describe("Evaluates Range Expression", () => {


### PR DESCRIPTION
## Features:
- Nuevo metodo `is` en el ASTNode para comparar un Nodo contra un Constructor
- Nuevo metodo `clone` en RuntimeEnvironment para hacer una deep copy del EnvStack 

## Fixes:
- Documentacion: Boton "Get Started" de la home del sitio web no enviaba a la ruta correcta.
- Documentacion: Ahora el highlighting del editor de codigo de la Home cambia segun el lenguaje
- Interpreter: Faltaba el metodo `visitTypeCast` para las expresiones `TypeCast`
- RuntimeEnvironment: El metodo `popEnv` recibia el `env` por paramentro incorrectamente, debia usar el atributo contenido en el objeto
- LazyRuntime: No se capturaba el entorno correctamente en `evaluateCons`. Capturaba la referencia en vez de clonarlo, provocando env leaks
- FunctionRuntime: Hacia `pushEnv` dos veces, una en `applyArguments` y otra en `apply`. Tampoco se liberaba correctamente el entorno al tirar error `NonExhaustivePatterns`
- TestRunner: En la funcion `isEquals`, no se comparaba correctamente las listas de caracteres con los strings
- LazyRuntime: La evaluación de `evaluateConcatLazy` ahora evalua el lado izquierdo de inmediato y postergar el derecho mediante un clon del contexto, evitando ejecuciones innecesarias y env leaks.
- Interpreter: Agregado casos de `Equal` y `NotEqual` a `visitComparisonOperation` para usar lazy evaluation
- Analyzer: Ahora las `inspections` pueden tener `args: undefined` como hay en algunos ejercicios de Miyuki 