### PR TITLE
Agregar Yu enum para los tipos en haskell parser

### DIFF
--- a/packages/yukigo-haskell-parser/src/typechecker/TypeBuilder.ts
+++ b/packages/yukigo-haskell-parser/src/typechecker/TypeBuilder.ts
@@ -10,7 +10,7 @@ import {
   ConstrainedType,
   ASTNode,
 } from "yukigo-ast";
-import { typeMappings } from "../utils/types.js";
+import { typeMappings, YUTYPES } from "../utils/types.js";
 import { CoreHM } from "./core.js";
 import { functionType, Type, TypeConstructor, TypeVar, stringType, charType } from "./checker.js";
 
@@ -44,8 +44,8 @@ export class TypeBuilder {
 
         // Uppercase = type constructor (e.g., Int, Bool, List)
         const primitive = typeMappings[n.value] || n.value;
-        if (primitive === "YuString") return stringType;
-        if (primitive === "YuChar") return charType;
+        if (primitive === YUTYPES.YuString) return stringType;
+        if (primitive === YUTYPES.YuChar) return charType;
         return {
           type: "TypeConstructor",
           name: primitive,
@@ -72,7 +72,7 @@ export class TypeBuilder {
         const elementType = n.values.accept(visitor);
         return {
           type: "TypeConstructor",
-          name: "List",
+          name: YUTYPES.List,
           args: [elementType],
         };
       },
@@ -81,7 +81,7 @@ export class TypeBuilder {
         const elementTypes = n.values.map((v) => v.accept(visitor));
         return {
           type: "TypeConstructor",
-          name: "Tuple",
+          name: YUTYPES.Tuple,
           args: elementTypes,
         };
       },

--- a/packages/yukigo-haskell-parser/src/typechecker/checker.ts
+++ b/packages/yukigo-haskell-parser/src/typechecker/checker.ts
@@ -13,7 +13,7 @@ import {
 import { InferenceEngine, PatternVisitor } from "./inference.js";
 import { CoreHM } from "./core.js";
 import { DeclarationCollectorVisitor } from "./DeclarationCollector.js";
-import { typeClasses as staticTypeClasses } from "../utils/types.js";
+import { typeClasses as staticTypeClasses, YUTYPES } from "../utils/types.js";
 
 export interface TypeVar {
   type: "TypeVar";
@@ -29,17 +29,17 @@ export interface TypeConstructor {
 }
 export interface FunctionType {
   type: "TypeConstructor";
-  name: "->";
+  name: YUTYPES.Arrow;
   args: [Type, Type];
 }
 export interface ListType {
   type: "TypeConstructor";
-  name: "List";
+  name: YUTYPES.List;
   args: [Type];
 }
 export interface TupleType {
   type: "TypeConstructor";
-  name: "Tuple";
+  name: YUTYPES.Tuple;
   args: Type[];
 }
 
@@ -62,17 +62,17 @@ export type Result<T> =
 
 export const booleanType: TypeConstructor = {
   type: "TypeConstructor",
-  name: "YuBoolean",
+  name: YUTYPES.YuBoolean,
   args: [],
 };
 export const numberType: TypeConstructor = {
   type: "TypeConstructor",
-  name: "YuNumber",
+  name: YUTYPES.YuNumber,
   args: [],
 };
 export const charType: TypeConstructor = {
   type: "TypeConstructor",
-  name: "YuChar",
+  name: YUTYPES.YuChar,
   args: [],
 };
 export const stringType: Type = listType(charType);
@@ -394,12 +394,7 @@ export class TypeChecker {
 }
 
 type SeenTypeNames = Map<number, string>;
-const YuNameMap = {
-  YuNumber: "YuNumber",
-  YuString: "YuString",
-  YuBoolean: "YuBoolean",
-  YuChar: "YuChar",
-};
+
 const getVarName = (
   id: number,
   name: string | undefined,
@@ -429,14 +424,14 @@ const formatBody = (t: Type, seen: SeenTypeNames): string => {
       : `${left} -> ${right}`;
   }
   if (isListType(t)) {
-    if (t.args[0].type === "TypeConstructor" && t.args[0].name === "YuChar") {
-      return "YuString";
+    if (t.args[0].type === "TypeConstructor" && t.args[0].name === YUTYPES.YuChar) {
+      return YUTYPES.YuString;
     }
     return `[${showType(t.args[0])}]`;
   }
   if (isTupleType(t)) return `(${t.args.map(showType.bind(this)).join(", ")})`;
 
-  const name = YuNameMap[t.name] || t.name;
+  const name = t.name;
   return t.args.length
     ? `${name} ${t.args.map((a) => formatBody(a, seen)).join(" ")}`
     : name;
@@ -476,26 +471,35 @@ export function getArity(type: Type): number {
 }
 
 export function isFunctionType(t: Type): t is FunctionType {
-  return t.type === "TypeConstructor" && t.name === "->" && t.args.length === 2;
+  return t.type === "TypeConstructor" && t.name === YUTYPES.Arrow && t.args.length === 2;
 }
 export function isListType(t: Type): t is ListType {
-  return t.name === "List";
+  return t.name === YUTYPES.List;
 }
 export function isTupleType(t: Type): t is TupleType {
-  return t.name === "Tuple";
+  return t.name === YUTYPES.Tuple;
 }
+
+// If either side is a string primitive or already inferred as stringType,
+// we treat the whole operation as string concatenation.
+export const isString = (t: Type) =>
+  (t.type === "TypeConstructor" && t.name === YUTYPES.YuString) ||
+  (t.type === "TypeConstructor" &&
+  t.name === YUTYPES.List &&
+  t.args[0].type === "TypeConstructor" &&
+  t.args[0].name === YUTYPES.YuChar);
 
 export function functionType(params: Type, returnType: Type): FunctionType {
   return {
     type: "TypeConstructor",
-    name: "->",
+    name: YUTYPES.Arrow,
     args: [params, returnType],
   };
 }
 export function listType(elementsType: Type): ListType {
   return {
     type: "TypeConstructor",
-    name: "List",
+    name: YUTYPES.List,
     args: [elementsType],
   };
 }

--- a/packages/yukigo-haskell-parser/src/typechecker/core.ts
+++ b/packages/yukigo-haskell-parser/src/typechecker/core.ts
@@ -1,6 +1,9 @@
+import { YUTYPES } from "../utils/types.js";
 import {
   charType,
   Environment,
+  isListType,
+  isString,
   Result,
   showType,
   Substitution,
@@ -104,11 +107,11 @@ export class CoreHM {
     if (rt2.type === "TypeVar") return this.unifyVar(rt2, rt1);
     if (rt1.type === "TypeConstructor" && rt2.type === "TypeConstructor") {
       const isStringList = (a: TypeConstructor, b: TypeConstructor) =>
-        (a.name === "YuString" && b.name === "List") ||
-        (b.name === "YuString" && a.name === "List");
+        (isString(a) && isListType(b)) ||
+        (isString(b) && isListType(a));
 
       if (isStringList(rt1, rt2)) {
-        const listType = rt1.name === "List" ? rt1 : rt2;
+        const listType = rt1.name === YUTYPES.List ? rt1 : rt2;
         return this.unify(listType.args[0], charType);
       }
 
@@ -166,12 +169,12 @@ export class CoreHM {
     } else if (rt.type === "TypeConstructor") {
       let typeName = rt.name;
       if (
-        typeName === "List" &&
+        typeName === YUTYPES.List &&
         rt.args.length === 1 &&
         rt.args[0].type === "TypeConstructor" &&
-        rt.args[0].name === "YuChar"
+        rt.args[0].name === YUTYPES.YuChar
       ) {
-        typeName = "YuString";
+        typeName = YUTYPES.YuString;
       }
 
       const instances = this.typeClasses.get(constraintName);

--- a/packages/yukigo-haskell-parser/src/typechecker/inference.ts
+++ b/packages/yukigo-haskell-parser/src/typechecker/inference.ts
@@ -78,9 +78,11 @@ import {
   FunctionRegistrarVisitor,
   FunctionCheckerVisitor,
   getReturnType,
+  isString,
 } from "./checker.js";
 import { CoreHM } from "./core.js";
 import { TypeBuilder } from "./TypeBuilder.js";
+import { YUTYPES } from "../utils/types.js";
 
 export class PatternVisitor implements Visitor<void> {
   constructor(
@@ -157,7 +159,7 @@ export class PatternVisitor implements Visitor<void> {
       tupleElementTypes = node.elements.map(() => this.coreHM.freshVar());
       const tupleType: Type = {
         type: "TypeConstructor",
-        name: "Tuple",
+        name: YUTYPES.Tuple,
         args: tupleElementTypes,
       };
 
@@ -410,7 +412,7 @@ export class InferenceEngine implements Visitor<Result<Type>> {
       success: true,
       value: {
         type: "TypeConstructor",
-        name: "YuNil",
+        name: YUTYPES.YuNil,
         args: [],
       },
     };
@@ -420,7 +422,7 @@ export class InferenceEngine implements Visitor<Result<Type>> {
       success: true,
       value: {
         type: "TypeConstructor",
-        name: "YuChar",
+        name: YUTYPES.YuChar,
         args: [],
       },
     };
@@ -737,15 +739,6 @@ export class InferenceEngine implements Visitor<Result<Type>> {
 
         const rightResult = node.right.accept(this);
         if (!rightResult.success) return rightResult;
-
-        // If either side is a string primitive or already inferred as stringType,
-        // we treat the whole operation as string concatenation.
-        const isString = (t: Type) =>
-          (t.type === "TypeConstructor" && t.name === "YuString") ||
-          (t.type === "TypeConstructor" &&
-            t.name === "List" &&
-            t.args[0].type === "TypeConstructor" &&
-            t.args[0].name === "YuChar");
 
         if (isString(leftResult.value) || isString(rightResult.value)) {
           const unifyLeft = this.coreHM.unify(leftResult.value, stringType);

--- a/packages/yukigo-haskell-parser/src/utils/types.ts
+++ b/packages/yukigo-haskell-parser/src/utils/types.ts
@@ -34,30 +34,44 @@ export const keywords = [
   "shouldThrow"
 ];
 
-export const typeMappings: { [key: string]: YukigoPrimitive } = {
-  Float: "YuNumber",
-  Double: "YuNumber",
-  Int: "YuNumber",
-  Integer: "YuNumber",
-  String: "YuString",
-  Char: "YuChar",
-  Boolean: "YuBoolean",
-  Bool: "YuBoolean",
+export enum YUTYPES { // primitivos 
+  YuNumber = "YuNumber", 
+  YuString = "YuString", 
+  YuChar = "YuChar", 
+  YuBoolean = "YuBoolean", 
+  YuNil = "YuNil", 
+  // constructores 
+  Tuple = "Tuple", 
+  List = "List", 
+  Arrow = "->" 
+}
+
+export const typeMappings: { [key: string]: YUTYPES } = {
+  Float: YUTYPES.YuNumber,
+  Double: YUTYPES.YuNumber,
+  Int: YUTYPES.YuNumber,
+  Integer: YUTYPES.YuNumber,
+  String: YUTYPES.YuString,
+  Char: YUTYPES.YuChar,
+  Boolean: YUTYPES.YuBoolean,
+  Bool: YUTYPES.YuBoolean,
 };
 
-export const typeClasses: Map<string, string[]> = new Map([
-  ["Bounded", ["YuChar", "YuNumber"]],
-  ["Enum", ["YuChar", "YuNumber"]],
-  ["Ord", ["YuNumber", "YuString", "YuChar"]],
-  ["Eq", ["YuNumber", "YuString", "YuChar", "YuBoolean"]],
-  ["Floating", ["YuNumber"]],
-  ["Fractional", ["YuNumber"]],
-  ["Integral", ["YuNumber"]],
-  ["Num", ["YuNumber"]],
-  ["Random", ["YuBoolean", "YuChar", "YuNumber"]],
-  ["Read", ["YuList", "YuChar", "YuNumber"]],
-  ["Real", ["YuNumber"]],
-  ["RealFloat", ["YuNumber"]],
-  ["RealFrac", ["YuNumber"]],
-  ["Show", ["YuNumber", "YuString", "YuChar", "YuList"]],
+export const typeClasses: Map<string, YUTYPES[]> = new Map([
+  ["Bounded", [YUTYPES.YuChar, YUTYPES.YuNumber]],
+  ["Enum", [YUTYPES.YuChar, YUTYPES.YuNumber]],
+  ["Ord", [YUTYPES.YuNumber, YUTYPES.YuString, YUTYPES.YuChar]],
+  ["Eq", [YUTYPES.YuNumber, YUTYPES.YuString, YUTYPES.YuChar, YUTYPES.YuBoolean]],
+  ["Floating", [YUTYPES.YuNumber]],
+  ["Fractional", [YUTYPES.YuNumber]],
+  ["Integral", [YUTYPES.YuNumber]],
+  ["Num", [YUTYPES.YuNumber]],
+  ["Random", [YUTYPES.YuBoolean, YUTYPES.YuChar, YUTYPES.YuNumber]],
+  ["Read", [YUTYPES.YuChar, YUTYPES.YuNumber]],
+  
+  ["Real", [YUTYPES.YuNumber]],
+  ["RealFloat", [YUTYPES.YuNumber]],
+  ["RealFrac", [YUTYPES.YuNumber]],
+  ["Show", [YUTYPES.YuNumber, YUTYPES.YuString, YUTYPES.YuChar]],
+  
 ]);


### PR DESCRIPTION
close #47 
Agregue el anum YUTYPES y lo conecte con los utils
Lo remplaze en todas las comparaciones del Typecheacker que tenian strings
Unifique los 2 maps que habia